### PR TITLE
Implement Croatian NER dataset download

### DIFF
--- a/takepod/dataload/ner_croatian.py
+++ b/takepod/dataload/ner_croatian.py
@@ -22,8 +22,11 @@ class NERCroatianXMLLoader:
     def __init__(self,
                  path='downloaded_datasets/',
                  tokenizer='split',
-                 tag_schema='IOB'):
-        """Constructor for Croatian NER dataset
+                 tag_schema='IOB',
+                 **kwargs):
+        """
+        Constructor for Croatian NER dataset.
+        Downloads and extracts the dataset.
 
         Parameters
         ----------
@@ -39,37 +42,26 @@ class NERCroatianXMLLoader:
                 prefixed with 'B-', the remaining tokens that belong to the
                 same entity are prefixed with 'I-'. The tokens that don't
                 belong to any named entity are labeled 'O'
+        **kwargs:
+            scp_user:
+                User on the host machine. Not required if the user on the
+                local machine matches the user on the host machine.
+            scp_private_key:
+                Path to the ssh private key eligible to access the host
+                machine. Not required on Unix if the private is in the default
+                location.
+            scp_pass_key:
+                Password for the ssh private key (optional). Can be omitted
+                if the private key is not encrypted.
         """
         self._data_dir = path
         self._tokenizer = get_tokenizer(tokenizer)
         self._label_resolver = self._get_label_resolver(tag_schema)
 
-    def download_and_extract(self, **kwargs):
-        """
-        Method downloads the dataset using SCP and unzips it.
-
-        Keyword arguments:
-        ----------
-        scp_user:
-            User on the host machine. Not required if the user on the
-            local machine matches the user on the host machine.
-        scp_private_key:
-            Path to the ssh private key eligible to access the host machine.
-            Not required on Unix if the private is in the default location.
-        scp_pass_key:
-            Password for the ssh private key (optional). Can be omitted
-            if the private key is not encrypted.
-        """
         download_location = os.path.join(
             self._data_dir,
             NERCroatianXMLLoader.NAME
         )
-        if os.path.isdir(download_location):
-            print("Already downloaded; try loading the dataset...")
-            return
-
-        print("Downloading and unzipping the Croatian NER dataset")
-
         LargeResource.BASE_RESOURCE_DIR = download_location
 
         if 'scp_user' not in kwargs:
@@ -91,8 +83,6 @@ class NERCroatianXMLLoader:
             SCPLargeResource.SCP_PASS_KEY: scp_pass_key
         }
         SCPLargeResource(**config)
-
-        print("Croatian NER dataset successfully downloaded and unzipped")
 
     def load_dataset(self):
         """

--- a/test/dataload/test_ner_croatian.py
+++ b/test/dataload/test_ner_croatian.py
@@ -181,8 +181,8 @@ def test_download_dataset_using_scp():
 
     LargeResource.BASE_RESOURCE_DIR = base
 
-    ner_croatian_xml_loader = NERCroatianXMLLoader(base)
-    ner_croatian_xml_loader.download_and_extract(
+    ner_croatian_xml_loader = NERCroatianXMLLoader(
+        base,
         scp_user='username',
         scp_private_key='private_key',
         scp_pass_key='pass'


### PR DESCRIPTION
```----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                          Stmts   Miss  Cover
-----------------------------------------------------------------
takepod/__init__.py                               1      0   100%
takepod/dataload/__init__.py                      0      0   100%
takepod/dataload/imdb.py                         28      1    96%
takepod/dataload/ner_croatian.py                 68      2    97%
takepod/dataload/pauzahr.py                      39     12    69%
takepod/datasets/__init__.py                      0      0   100%
takepod/datasets/pauza_dataset.py                39      0   100%
takepod/examples/__init__.py                      0      0   100%
takepod/examples/dataset_example.py               7      7     0%
takepod/metrics/__init__.py                       0      0   100%
takepod/metrics/metrics.py                        3      0   100%
takepod/models/__init__.py                        0      0   100%
takepod/models/base_model.py                      9      3    67%
takepod/models/simple_sentiment_analysis.py      50      0   100%
takepod/preproc/__init__.py                       0      0   100%
takepod/preproc/stemmer/__init__.py               0      0   100%
takepod/preproc/stemmer/croatian_stemmer.py      35      0   100%
takepod/preproc/tokenizers.py                    16      0   100%
takepod/preproc/transform.py                     16      0   100%
takepod/storage/__init__.py                       0      0   100%
takepod/storage/dataset.py                      148      0   100%
takepod/storage/downloader.py                    54     15    72%
takepod/storage/example.py                       56      0   100%
takepod/storage/field.py                         72      0   100%
takepod/storage/iterator.py                      97      0   100%
takepod/storage/large_resource.py                51      1    98%
takepod/storage/utility.py                       23      6    74%
takepod/storage/vectorizer.py                    99      7    93%
takepod/storage/vocab.py                         86      4    95%
-----------------------------------------------------------------
TOTAL                                           997     58    94%```