### PR TITLE
Fix NERCroatianXMLLoader not to change the BASE_RESOURCE_DIR

### DIFF
--- a/takepod/dataload/ner_croatian.py
+++ b/takepod/dataload/ner_croatian.py
@@ -12,8 +12,7 @@ class NERCroatianXMLLoader:
     """Simple croatian NER class"""
 
     URL = '/storage/takepod_data/datasets/CroatianNERDataset.zip'
-    NAME = 'ner_croatian'
-    RESOURCE_NAME = "CroatianNERDataset"
+    NAME = "CroatianNERDataset"
     SCP_HOST = "djurdja.takelab.fer.hr"
     ARCHIVE_TYPE = "zip"
 
@@ -58,12 +57,6 @@ class NERCroatianXMLLoader:
         self._tokenizer = get_tokenizer(tokenizer)
         self._label_resolver = self._get_label_resolver(tag_schema)
 
-        download_location = os.path.join(
-            self._data_dir,
-            NERCroatianXMLLoader.NAME
-        )
-        LargeResource.BASE_RESOURCE_DIR = download_location
-
         if 'scp_user' not in kwargs:
             # if your username is same as one on djurdja
             scp_user = getpass.getuser()
@@ -75,7 +68,7 @@ class NERCroatianXMLLoader:
 
         config = {
             LargeResource.URI: NERCroatianXMLLoader.URL,
-            LargeResource.RESOURCE_NAME: NERCroatianXMLLoader.RESOURCE_NAME,
+            LargeResource.RESOURCE_NAME: NERCroatianXMLLoader.NAME,
             LargeResource.ARCHIVE: NERCroatianXMLLoader.ARCHIVE_TYPE,
             SCPLargeResource.SCP_HOST_KEY: NERCroatianXMLLoader.SCP_HOST,
             SCPLargeResource.SCP_USER_KEY: scp_user,
@@ -96,8 +89,7 @@ class NERCroatianXMLLoader:
             delimited by tuple (None, None)
         """
         source_dir_location = os.path.join(self._data_dir,
-                                           NERCroatianXMLLoader.NAME,
-                                           NERCroatianXMLLoader.RESOURCE_NAME)
+                                           NERCroatianXMLLoader.NAME)
 
         tokenized_documents = []
 

--- a/test/dataload/test_ner_croatian.py
+++ b/test/dataload/test_ner_croatian.py
@@ -93,11 +93,11 @@ expected_output_2 = [
 def test_load_dataset(tmpdir, expected_data, expected_output):
     base = tempfile.mkdtemp()
     assert os.path.exists(base)
+    LargeResource.BASE_RESOURCE_DIR = base
 
     unzipped_xml_directory = os.path.join(
         base,
-        NERCroatianXMLLoader.NAME,
-        NERCroatianXMLLoader.RESOURCE_NAME
+        NERCroatianXMLLoader.NAME
     )
 
     os.makedirs(unzipped_xml_directory)
@@ -125,11 +125,11 @@ def test_load_dataset(tmpdir, expected_data, expected_output):
 def test_load_dataset_with_multiple_documents():
     base = tempfile.mkdtemp()
     assert os.path.exists(base)
+    LargeResource.BASE_RESOURCE_DIR = base
 
     unzipped_xml_directory = os.path.join(
         base,
-        NERCroatianXMLLoader.NAME,
-        NERCroatianXMLLoader.RESOURCE_NAME
+        NERCroatianXMLLoader.NAME
     )
 
     os.makedirs(unzipped_xml_directory)


### PR DESCRIPTION
As @domi385 mentioned in [this](https://github.com/FilipBolt/takepod/pull/28#pullrequestreview-192601052) comment, the BASE_RESOURCE_DIR in LargeResource should not be modified by any non-user class.
Also, the directory structure was simplified, removing one unnecessary level.

```----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                          Stmts   Miss  Cover
-----------------------------------------------------------------
takepod/__init__.py                               1      0   100%
takepod/dataload/__init__.py                      0      0   100%
takepod/dataload/imdb.py                         28      1    96%
takepod/dataload/ner_croatian.py                 65      0   100%
takepod/dataload/pauzahr.py                      39     12    69%
takepod/datasets/__init__.py                      0      0   100%
takepod/datasets/pauza_dataset.py                39      0   100%
takepod/examples/__init__.py                      0      0   100%
takepod/examples/dataset_example.py               7      7     0%
takepod/metrics/__init__.py                       0      0   100%
takepod/metrics/metrics.py                        3      0   100%
takepod/models/__init__.py                        0      0   100%
takepod/models/base_model.py                      9      3    67%
takepod/models/simple_sentiment_analysis.py      50      0   100%
takepod/preproc/__init__.py                       0      0   100%
takepod/preproc/stemmer/__init__.py               0      0   100%
takepod/preproc/stemmer/croatian_stemmer.py      35      0   100%
takepod/preproc/tokenizers.py                    16      0   100%
takepod/preproc/transform.py                     16      0   100%
takepod/storage/__init__.py                       0      0   100%
takepod/storage/dataset.py                      148      0   100%
takepod/storage/downloader.py                    54     15    72%
takepod/storage/example.py                       56      0   100%
takepod/storage/field.py                         72      0   100%
takepod/storage/iterator.py                      97      0   100%
takepod/storage/large_resource.py                51      1    98%
takepod/storage/utility.py                       23      6    74%
takepod/storage/vectorizer.py                    99      7    93%
takepod/storage/vocab.py                         86      4    95%
-----------------------------------------------------------------
TOTAL                                           994     56    94%
```