### PR TITLE
Implement TokenizedField

### DIFF
--- a/takepod/storage/field.py
+++ b/takepod/storage/field.py
@@ -316,3 +316,47 @@ class Field(object):
                 row = np.append(row, [pad_symbol] * diff)
 
         return row
+
+
+class TokenizedField(Field):
+    """
+    Tokenized version of the Field. Holds the preprocessing and
+    numericalization logic for the pre-tokenized dataset fields.
+    """
+
+    def __init__(self,
+                 name,
+                 vocab=None,
+                 eager=True,
+                 custom_numericalize=float,
+                 is_target=False,
+                 fixed_length=None):
+
+        super().__init__(
+            name=name,
+            vocab=vocab,
+            sequential=False,
+            store_raw=True,
+            eager=eager,
+            custom_numericalize=custom_numericalize,
+            is_target=is_target,
+            fixed_length=fixed_length
+        )
+
+    def update_vocab(self, raw, tokenized):
+        """
+        Updates the vocab with new data.
+        Only the raw form is used to update the vocabulary, since the
+        TokenizedField defaults to sequential=False.
+
+        Parameters
+        ----------
+        raw : list
+            The raw form of the data point used to update the vocab.
+        tokenized : any
+            The tokenized form of the data point (not used).
+        """
+        if not self.use_vocab:
+            return
+
+        self.vocab += raw

--- a/test/storage/test_field.py
+++ b/test/storage/test_field.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from mock import patch
 
-from takepod.storage.field import Field
+from takepod.storage.field import Field, TokenizedField
 
 ONE_TO_FIVE = [1, 2, 3, 4, 5]
 
@@ -378,3 +378,21 @@ def test_field_is_target():
     assert not f1.is_target
     assert f2.is_target
     assert not f3.is_target
+
+
+@pytest.mark.parametrize(
+    "use_vocab, expected_vocab_values",
+    [
+        (False, []),
+        (True, ["some", "text"]),
+    ]
+)
+def test_tokenized_field_update_vocab(use_vocab, expected_vocab_values, vocab):
+    f = TokenizedField(name="F", vocab=vocab if use_vocab else None)
+
+    raw_value = ["some", "text"]
+    tokenized_value = None
+
+    f.update_vocab(raw_value, tokenized_value)
+
+    assert vocab.values == expected_vocab_values


### PR DESCRIPTION
```----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                          Stmts   Miss  Cover
-----------------------------------------------------------------
takepod/__init__.py                              10      0   100%
takepod/dataload/__init__.py                      0      0   100%
takepod/dataload/imdb.py                         28      1    96%
takepod/dataload/ner_croatian.py                 65      0   100%
takepod/dataload/pauzahr.py                      39     12    69%
takepod/datasets/__init__.py                      2      0   100%
takepod/datasets/catacx_comments_dataset.py      40      4    90%
takepod/datasets/pauza_dataset.py                39      0   100%
takepod/examples/__init__.py                      0      0   100%
takepod/examples/dataset_example.py               7      7     0%
takepod/metrics/__init__.py                       2      0   100%
takepod/metrics/metrics.py                        3      0   100%
takepod/models/__init__.py                        3      0   100%
takepod/models/base_model.py                      9      3    67%
takepod/models/simple_sentiment_analysis.py      50      0   100%
takepod/preproc/__init__.py                       4      0   100%
takepod/preproc/stemmer/__init__.py               2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py      35      0   100%
takepod/preproc/tokenizers.py                    16      0   100%
takepod/preproc/transform.py                     16      0   100%
takepod/storage/__init__.py                       9      0   100%
takepod/storage/dataset.py                      148      0   100%
takepod/storage/downloader.py                    54     15    72%
takepod/storage/example.py                       56      0   100%
takepod/storage/field.py                         79      0   100%
takepod/storage/iterator.py                      97      0   100%
takepod/storage/large_resource.py                51      1    98%
takepod/storage/utility.py                       23      6    74%
takepod/storage/vectorizer.py                    99      7    93%
takepod/storage/vocab.py                         86      4    95%
-----------------------------------------------------------------
TOTAL                                          1072     60    94%```