### PR TITLE
Casing prepro

### DIFF
--- a/takepod/preproc/lemmatizer/croatian_lemmatizer.py
+++ b/takepod/preproc/lemmatizer/croatian_lemmatizer.py
@@ -6,6 +6,7 @@ import os
 import getpass
 import functools
 
+from takepod.preproc.util import capitalize_target_like_source
 from takepod.storage.large_resource import SCPLargeResource
 
 
@@ -59,6 +60,7 @@ class CroatianLemmatizer(SCPLargeResource):
         super(CroatianLemmatizer, self).__init__(
             **kwargs)
 
+    @capitalize_target_like_source
     def lemmatize_word(self, word):
         """Returns the lemma for the provided word if
         there is a word in a dictionary, otherwise returns the word.
@@ -76,13 +78,7 @@ class CroatianLemmatizer(SCPLargeResource):
         """
 
         try:
-            is_lower = word.islower()
-            word_lower = word if is_lower else word.lower()
-            lemma = self._word2lemma[word_lower]
-            if is_lower:
-                return lemma
-            else:
-                return _uppercase_target_like_source(word, lemma)
+            return self._word2lemma[word]
         except KeyError:
             # TODO: insert log statement that a word is being returned
             return word

--- a/takepod/preproc/stemmer/croatian_stemmer.py
+++ b/takepod/preproc/stemmer/croatian_stemmer.py
@@ -21,6 +21,8 @@ import re
 import os
 import functools
 
+from takepod.preproc.util import capitalize_target_like_source
+
 
 class CroatianStemmer:
     """Simple stemmer for Croatian language"""
@@ -113,6 +115,7 @@ class CroatianStemmer:
                     return root
         return word
 
+    @capitalize_target_like_source
     def stem_word(self, word):
         '''
         Returns the root or roots of a word,
@@ -129,12 +132,10 @@ class CroatianStemmer:
             Croatian word root plus derivational morphemes
         '''
 
-        if word.lower() in self.__stop:
+        if word in self.__stop:
             return word
-        stem = self.root_word(self.transform(word.lower()))
-        return "".join(list(
-            stem[i].upper() if c.isupper() else stem[i] for i, c in
-            zip(range(len(stem)), word)))
+        else:
+            return self.root_word(self.transform(word))
 
 
 def _stemmer_posttokenized_hook(raw, tokenized, stemmer):

--- a/takepod/preproc/util.py
+++ b/takepod/preproc/util.py
@@ -1,0 +1,45 @@
+"""Module contains utility functions to preprocess text data"""
+
+
+def capitalize_target_like_source(func):
+    """Capitalization decorator of a method that processes a word.
+    Method invokes the parameter function
+    with a lowercased input, then capitalizes
+    the return value such that capitalization corresponds
+    to the original input provided
+
+    Parameters
+    ----------
+    func : function
+        function which gets called, MUST be a class member with one argument
+        like def func(self, word)
+
+    Returns
+    -------
+    wrapper : function
+        decorator function to decorate func with
+    """
+
+    def _wrapper(*args, **kwargs):
+        source = args[1]
+
+        is_lower = source.islower()
+        source_lower = source if is_lower else source.lower()
+
+        target = func(args[0], source_lower)
+
+        if is_lower:
+            return target
+        else:
+            return _uppercase_target_like_source(source, target)
+    return _wrapper
+
+
+def _uppercase_target_like_source(source, target):
+    uppercased_target = ''.join([
+        target[i].upper()
+        if s.isupper() and s.lower() == target[i] else target[i]
+        for i, s in zip(range(len(target)), source)
+    ])
+    uppercased_target += target[len(source):]
+    return uppercased_target


### PR DESCRIPTION
Using decorator to use lazy casing to avoid unnecessary calls for lowercasing in both stemmer and lemmatizer. 

```
> py.test --cov=takepod test                                                                    [NORMAL]
========================================== test session starts ==========================================
platform linux -- Python 3.6.7, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/filip/Documents/Doktorski/projects, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 323 items

test/test_pytest.py .                                                                             [  0%]
test/dataload/test_imdb.py .                                                                      [  0%]
test/dataload/test_ner_croatian.py ......                                                         [  2%]
test/dataload/test_pauzahr.py ..                                                                  [  3%]
test/datasets/test_catacx_comments_dataset.py .                                                   [  3%]
test/datasets/test_croatian_ner_dataset.py ...                                                    [  4%]
test/datasets/test_pauzahr_dataset.py ...                                                         [  5%]
test/examples/test_model_example.py .......                                                       [  7%]
test/metrics/test_metrics.py .                                                                    [  7%]
test/models/test_fc_model.py .                                                                    [  8%]
test/models/test_simple_trainers.py ...                                                           [  8%]
test/models/test_svm_model.py .                                                                   [  9%]
test/preproc/test_lemmatizer.py ................                                                  [ 14%]
test/preproc/test_stemmer.py .........                                                            [ 17%]
test/preproc/test_transform.py .....                                                              [ 18%]
test/storage/test_dataset.py .................................................................... [ 39%]
...........                                                                                       [ 43%]
test/storage/test_downloader.py ...........                                                       [ 46%]
test/storage/test_example.py ..........................                                           [ 54%]
test/storage/test_field.py .................................................                      [ 69%]
test/storage/test_iterator.py ..............................                                      [ 78%]
test/storage/test_large_resource.py .........                                                     [ 81%]
test/storage/test_vectorizer.py .........................                                         [ 89%]
test/storage/test_vocab.py ..................................                                     [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                                Stmts   Miss  Cover
-----------------------------------------------------------------------
takepod/__init__.py                                    10      0   100%
takepod/dataload/__init__.py                            0      0   100%
takepod/dataload/imdb.py                               28      1    96%
takepod/dataload/ner_croatian.py                       65      0   100%
takepod/dataload/pauzahr.py                            39     12    69%
takepod/datasets/__init__.py                            2      0   100%
takepod/datasets/catacx_comments_dataset.py            40      4    90%
takepod/datasets/croatian_ner_dataset.py               37      0   100%
takepod/datasets/pauza_dataset.py                      40      0   100%
takepod/examples/__init__.py                            0      0   100%
takepod/examples/dataset_example.py                    12     12     0%
takepod/examples/model_example.py                      52     21    60%
takepod/metrics/__init__.py                             2      0   100%
takepod/metrics/metrics.py                              3      0   100%
takepod/models/__init__.py                              2      0   100%
takepod/models/base_model.py                           12      4    67%
takepod/models/base_trainer.py                          6      1    83%
takepod/models/fc_model.py                             11      0   100%
takepod/models/simple_trainers.py                      17      0   100%
takepod/models/svm_model.py                            10      0   100%
takepod/preproc/__init__.py                             5      0   100%
takepod/preproc/lemmatizer/__init__.py                  2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py      60      1    98%
takepod/preproc/stemmer/__init__.py                     2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py            40      0   100%
takepod/preproc/tokenizers.py                          16      0   100%
takepod/preproc/transform.py                           16      0   100%
takepod/preproc/util.py                                14      0   100%
takepod/storage/__init__.py                             9      0   100%
takepod/storage/dataset.py                            152      0   100%
takepod/storage/downloader.py                          54     15    72%
takepod/storage/example.py                             56      0   100%
takepod/storage/field.py                               95      1    99%
takepod/storage/iterator.py                            97      0   100%
takepod/storage/large_resource.py                      51      1    98%
takepod/storage/utility.py                             23      6    74%
takepod/storage/vectorizer.py                         104      7    93%
takepod/storage/vocab.py                               94      4    96%
-----------------------------------------------------------------------
TOTAL                                                1278     90    93%


====================================== 323 passed in 1.68 seconds =======================================

```