### PR TITLE
Lemmatizer oov flag

### DIFF
--- a/takepod/preproc/lemmatizer/croatian_lemmatizer.py
+++ b/takepod/preproc/lemmatizer/croatian_lemmatizer.py
@@ -64,14 +64,18 @@ class CroatianLemmatizer(SCPLargeResource):
             **kwargs)
 
     @capitalize_target_like_source
-    def lemmatize_word(self, word):
+    def lemmatize_word(self, word, **kwargs):
         """Returns the lemma for the provided word if
-        there is a word in a dictionary, otherwise returns the word.
+        there is a word in a dictionary. If not found,
+        returns the word if none_if_oov=False, and None otherwise.
 
         Parameters
         ----------
         word : str
             A Croatian language word to lemmatize
+        none_if_oov : bool
+            A flag indicating whether to return None or the original
+            word if the word is not in a dictionary. Passed via kwargs.
 
         Returns
         -------
@@ -79,12 +83,16 @@ class CroatianLemmatizer(SCPLargeResource):
             Lemma of the word uppercased at the same chars as
             the original word
         """
+        try:
+                none_if_oov = kwargs['none_if_oov']
+        except KeyError:
+                none_if_oov = False
 
         try:
             return self._word2lemma[word]
         except KeyError:
             _LOGGER.info("Word is being returned instead of lemma.")
-            return word
+            return word if not none_if_oov else None
 
     def get_words_for_lemma(self, lemma):
         """Returns a list of words that shares the provided lemma.

--- a/takepod/preproc/stemmer/croatian_stemmer.py
+++ b/takepod/preproc/stemmer/croatian_stemmer.py
@@ -135,7 +135,7 @@ class CroatianStemmer:
         return word
 
     @capitalize_target_like_source
-    def stem_word(self, word):
+    def stem_word(self, word, **kwargs):
         '''
         Returns the root or roots of a word,
         together with any derivational affixes

--- a/takepod/preproc/util.py
+++ b/takepod/preproc/util.py
@@ -13,8 +13,9 @@ def capitalize_target_like_source(func):
     Parameters
     ----------
     func : function
-        function which gets called, MUST be a class member with one argument
-        like def func(self, word)
+        function which gets called, MUST be a class member with one
+        positional argument (like def func(self, word), but may contain
+        additional keyword arguments (like func(self, word, my_arg='my_value'))
 
     Returns
     -------
@@ -28,7 +29,7 @@ def capitalize_target_like_source(func):
         is_lower = source.islower()
         source_lower = source if is_lower else source.lower()
 
-        target = func(args[0], source_lower)
+        target = func(args[0], source_lower, **kwargs)
 
         if is_lower:
             return target

--- a/test/preproc/test_lemmatizer.py
+++ b/test/preproc/test_lemmatizer.py
@@ -141,3 +141,9 @@ def mock_lemmatizer(molex14_lemma2word, molex14_word2lemma):
         lemmatizer.MOLEX14_LEMMA2WORD = molex14_lemma2word
         lemmatizer.MOLEX14_WORD2LEMMA = molex14_word2lemma
         return lemmatizer
+
+
+def test_lemmatize_oov(mock_lemmatizer):
+    oov_word = 'outofvocabularyword'
+    received_lemma = mock_lemmatizer.lemmatize_word(oov_word, none_if_oov=True)
+    assert received_lemma is None


### PR DESCRIPTION
Added optional flag to the lemmatizer which makes it possible to select whether `word_lemmatize()` outputs the original word or _None_ if the word was not found in the lexicon.
While implementing this, it was necessary to modify a wrapper in `util.py`. This PR contains these modifications as well, along with the changes to all modules this wrapper appears in. Everything is backwards-compatible.

```platform linux -- Python 3.6.5, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/leonardvh/takepod_dev/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 353 items                                                                                                                                                                                                

test/dataload/test_ner_croatian.py ......                                                                                                                                                                    [  1%]
test/datasets/test_catacx_comments_dataset.py .                                                                                                                                                              [  1%]
test/datasets/test_catacx_dataset.py ..                                                                                                                                                                      [  2%]
test/datasets/test_croatian_ner_dataset.py ...                                                                                                                                                               [  3%]
test/datasets/test_imdb_dataset.py ...                                                                                                                                                                       [  4%]
test/datasets/test_pauzahr_dataset.py ...                                                                                                                                                                    [  5%]
test/examples/test_model_example.py .......                                                                                                                                                                  [  7%]
test/metrics/test_metrics.py s                                                                                                                                                                               [  7%]
test/models/test_fc_model.py s                                                                                                                                                                               [  7%]
test/models/test_simple_trainers.py ...                                                                                                                                                                      [  8%]
test/models/test_svm_model.py s                                                                                                                                                                              [  8%]
test/preproc/test_lemmatizer.py .................                                                                                                                                                            [ 13%]
test/preproc/test_stemmer.py .........                                                                                                                                                                       [ 16%]
test/preproc/test_stop_words.py ....                                                                                                                                                                         [ 17%]
test/preproc/test_util.py ......                                                                                                                                                                             [ 18%]
test/storage/test_dataset.py .........................................................................................                                                                                       [ 44%]
test/storage/test_downloader.py ...........                                                                                                                                                                  [ 47%]
test/storage/test_example.py ........................ss                                                                                                                                                      [ 54%]
test/storage/test_field.py .........................................................                                                                                                                         [ 70%]
test/storage/test_iterator.py ................................                                                                                                                                               [ 79%]
test/storage/test_large_resource.py .........                                                                                                                                                                [ 82%]
test/storage/test_vectorizer.py ............................                                                                                                                                                 [ 90%]
test/storage/test_vocab.py ..................................                                                                                                                                                [100%]

----------- coverage: platform linux, python 3.6.5-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod/__init__.py                                    15      0   100%
takepod/dataload/__init__.py                            0      0   100%
takepod/dataload/ner_croatian.py                       69      0   100%
takepod/datasets/__init__.py                            3      0   100%
takepod/datasets/catacx_comments_dataset.py            40      4    90%   54-67
takepod/datasets/catacx_dataset.py                     55      3    95%   28-29, 48
takepod/datasets/croatian_ner_dataset.py               37      0   100%
takepod/datasets/imdb_sentiment_dataset.py             48      0   100%
takepod/datasets/pauza_dataset.py                      36      0   100%
takepod/examples/__init__.py                            0      0   100%
takepod/examples/dataset_example.py                    14     14     0%   2-28
takepod/examples/model_example.py                      49     21    57%   62-78, 85-87, 95-108, 114-115
takepod/examples/ner_example.py                        92     92     0%   3-196
takepod/examples/vectors_example.py                    15     15     0%   3-25
takepod/metrics/__init__.py                             2      0   100%
takepod/metrics/metrics.py                             10      2    80%   16, 21
takepod/models/__init__.py                              2      0   100%
takepod/models/base_model.py                           12      4    67%   36, 55, 78, 104
takepod/models/base_trainer.py                          6      1    83%   29
takepod/models/blcc/__init__.py                         0      0   100%
takepod/models/blcc/chain_crf.py                      171    171     0%   6-409
takepod/models/blcc_model.py                           93     93     0%   2-218
takepod/models/fc_model.py                             16      5    69%   26-27, 33, 36-37
takepod/models/simple_trainers.py                      17      0   100%
takepod/models/svm_model.py                            15      4    73%   18, 21, 24-25
takepod/preproc/__init__.py                             4      0   100%
takepod/preproc/lemmatizer/__init__.py                  2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py      69      1    99%   205
takepod/preproc/stemmer/__init__.py                     2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py            46      0   100%
takepod/preproc/stop_words.py                          13      0   100%
takepod/preproc/tokenizers.py                          21      0   100%
takepod/preproc/util.py                                35      0   100%
takepod/storage/__init__.py                             9      0   100%
takepod/storage/dataset.py                            302      7    98%   872, 908-911, 971-974
takepod/storage/downloader.py                          54     15    72%   45, 113-132, 160
takepod/storage/example.py                             62     11    82%   226-242, 258
takepod/storage/field.py                              134      4    97%   416-418, 517
takepod/storage/iterator.py                           159     13    92%   473-478, 481-485, 523, 571, 579, 600-604, 607
takepod/storage/large_resource.py                      61      2    97%   109, 143
takepod/storage/utility.py                             28      9    68%   53-55, 77-82
takepod/storage/vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod/storage/vocab.py                              112      7    94%   232-235, 318, 322, 324, 326, 345
---------------------------------------------------------------------------------
TOTAL                                                2085    517    75%


====================================================================================== 348 passed, 5 skipped in 3.57 seconds =======================================================================================```