### PR TITLE
Added option to let multilabel field calculate num_of_classes

### DIFF
--- a/takepod/datasets/__init__.py
+++ b/takepod/datasets/__init__.py
@@ -3,4 +3,4 @@
 from .pauza_dataset import PauzaHRDataset
 from .catacx_dataset import CatacxDataset
 
-__all__ = ["PauzaHRDataset", CatacxDataset]
+__all__ = ["PauzaHRDataset", "CatacxDataset"]

--- a/takepod/storage/field.py
+++ b/takepod/storage/field.py
@@ -564,7 +564,7 @@ class MultilabelField(TokenizedField):
 
     def __init__(self,
                  name,
-                 num_of_classes = None,
+                 num_of_classes=None,
                  vocab=None,
                  eager=True,
                  allow_missing_data=False,
@@ -576,9 +576,10 @@ class MultilabelField(TokenizedField):
                 name : str
                     Field name, used for referencing data in the dataset.
 
-                num_of_classes : int
+                num_of_classes : int, optional
                     Number of valid classes.
                     Also defines size of the numericalized vector.
+                    If none, size of the vocabulary is used.
 
                 vocab : Vocab
                     A vocab that this field will update after preprocessing and
@@ -630,6 +631,7 @@ class MultilabelField(TokenizedField):
                          custom_numericalize=custom_numericalize)
 
     def finalize(self):
+        super().finalize()
         if self.num_of_classes is None:
             self.fixed_length = self.num_of_classes = len(self.vocab)
 
@@ -639,8 +641,6 @@ class MultilabelField(TokenizedField):
                         f" Declared: {self.num_of_classes}, Actual: {len(self.vocab)}"
             _LOGGER.error(error_msg)
             raise ValueError(error_msg)
-
-        super().finalize()
 
     def _numericalize_tokens(self, tokens):
         if self.use_vocab:

--- a/test/storage/test_field.py
+++ b/test/storage/test_field.py
@@ -559,7 +559,7 @@ def test_tokenized_field_vocab_non_string():
 
 def test_multilabel_field_specials_in_vocab_fail():
     with pytest.raises(ValueError):
-        MultilabelField("bla",
+        MultilabelField(name="bla",
                         vocab=Vocab(specials=(SpecialVocabSymbols.UNK,)),
                         num_of_classes=10)
 
@@ -587,7 +587,7 @@ def test_multilabel_field_vocab_numericalization(tokens):
 
 def test_multilabel_field_class_count():
     vocab = Vocab(specials=())
-    field = MultilabelField("test field", vocab=vocab)
+    field = MultilabelField(name="test field", num_of_classes=None, vocab=vocab)
 
     example_1 = ["class1", "class2", "class3", "class4"]
     example_2 = ["class1", "class2", "class3"]
@@ -608,12 +608,12 @@ def test_multilabel_field_class_count():
 @pytest.mark.parametrize("tokens, expected_numericalization",
                          [
                              (
-                                     ["class1", "class2", "class3", "class4"],
-                                     np.array([1, 1, 1, 1, 0, 0])
+                                 ["class1", "class2", "class3", "class4"],
+                                 np.array([1, 1, 1, 1, 0, 0])
                              ),
                              (
-                                     [],
-                                     np.array([0, 0, 0, 0, 0, 0])
+                                 [],
+                                 np.array([0, 0, 0, 0, 0, 0])
                              )
                          ])
 def test_multilabel_field_custom_numericalization(tokens, expected_numericalization):
@@ -626,7 +626,8 @@ def test_multilabel_field_custom_numericalization(tokens, expected_numericalizat
         "class6": 5
     }
 
-    field = MultilabelField("test field", 6, custom_numericalize=index_dict.get)
+    field = MultilabelField(name="test field", num_of_classes=6,
+                            custom_numericalize=index_dict.get)
     preprocessed = field.preprocess(tokens)
     field.finalize()
 
@@ -637,7 +638,7 @@ def test_multilabel_field_custom_numericalization(tokens, expected_numericalizat
 
 def test_multilabel_too_many_classes_in_data_exception():
     vocab = Vocab(specials=())
-    field = MultilabelField("test_field", num_of_classes=3, vocab=vocab)
+    field = MultilabelField(name="test_field", num_of_classes=3, vocab=vocab)
 
     for data in "cls1", "cls2", "cls3", "cls4":
         field.preprocess(data)


### PR DESCRIPTION
```
platform linux -- Python 3.6.7, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/ivan/Repositories/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 370 items                                                                                                 

test/dataload/test_ner_croatian.py ......                                                                     [  1%]
test/datasets/test_catacx_comments_dataset.py .                                                               [  1%]
test/datasets/test_catacx_dataset.py ..                                                                       [  2%]
test/datasets/test_croatian_ner_dataset.py ...                                                                [  3%]
test/datasets/test_imdb_dataset.py ...                                                                        [  4%]
test/datasets/test_pauzahr_dataset.py ...                                                                     [  4%]
test/examples/test_model_example.py .......                                                                   [  6%]
test/metrics/test_metrics.py .                                                                                [  7%]
test/models/test_fc_model.py .                                                                                [  7%]
test/models/test_simple_trainers.py ...                                                                       [  8%]
test/models/test_svm_model.py .                                                                               [  8%]
test/preproc/test_lemmatizer.py .................                                                             [ 12%]
test/preproc/test_stemmer.py .........                                                                        [ 15%]
test/preproc/test_stop_words.py ....                                                                          [ 16%]
test/preproc/test_util.py ......                                                                              [ 18%]
test/storage/test_dataset.py ................................................................................ [ 39%]
.........                                                                                                     [ 42%]
test/storage/test_downloader.py ...........                                                                   [ 45%]
test/storage/test_example_factory.py ....................................                                     [ 54%]
test/storage/test_field.py ..............................................................                     [ 71%]
test/storage/test_iterator.py ..................................                                              [ 80%]
test/storage/test_large_resource.py .........                                                                 [ 83%]
test/storage/test_vectorizer.py ............................                                                  [ 90%]
test/storage/test_vocab.py ..................................                                                 [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod/__init__.py                                    15      0   100%
takepod/dataload/__init__.py                            0      0   100%
takepod/dataload/ner_croatian.py                       69      0   100%
takepod/datasets/__init__.py                            3      0   100%
takepod/datasets/catacx_comments_dataset.py            40      4    90%   53-66
takepod/datasets/catacx_dataset.py                     56      3    95%   28-29, 48
takepod/datasets/croatian_ner_dataset.py               38      0   100%
takepod/datasets/imdb_sentiment_dataset.py             49      0   100%
takepod/datasets/pauza_dataset.py                      37      0   100%
takepod/examples/__init__.py                            0      0   100%
takepod/examples/dataset_example.py                    14     14     0%   2-28
takepod/examples/model_example.py                      49     21    57%   62-78, 85-87, 95-108, 114-115
takepod/examples/ner_example.py                        92     92     0%   3-196
takepod/examples/vectors_example.py                    15     15     0%   3-25
takepod/metrics/__init__.py                             2      0   100%
takepod/metrics/metrics.py                             10      3    70%   8-9, 21
takepod/models/__init__.py                              2      0   100%
takepod/models/base_model.py                           12      4    67%   36, 55, 78, 104
takepod/models/base_trainer.py                          6      1    83%   29
takepod/models/blcc/__init__.py                         0      0   100%
takepod/models/blcc/chain_crf.py                      171    171     0%   6-409
takepod/models/blcc_model.py                           93     93     0%   2-218
takepod/models/fc_model.py                             16      2    88%   9-10
takepod/models/simple_trainers.py                      17      0   100%
takepod/models/svm_model.py                            15      2    87%   9-10
takepod/preproc/__init__.py                             4      0   100%
takepod/preproc/lemmatizer/__init__.py                  2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py      69      1    99%   205
takepod/preproc/stemmer/__init__.py                     2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py            46      0   100%
takepod/preproc/stop_words.py                          13      0   100%
takepod/preproc/tokenizers.py                          21      0   100%
takepod/preproc/util.py                                35      0   100%
takepod/storage/__init__.py                             9      0   100%
takepod/storage/dataset.py                            303      4    99%   872, 971-974
takepod/storage/downloader.py                          54     15    72%   45, 113-132, 160
takepod/storage/example_factory.py                     74     14    81%   101-107, 165-166, 192-202, 218
takepod/storage/field.py                              161      4    98%   416-418, 528
takepod/storage/iterator.py                           159     13    92%   475-480, 483-487, 525, 574, 581, 602-606, 609
takepod/storage/large_resource.py                      61      2    97%   109, 143
takepod/storage/utility.py                             28      9    68%   53-55, 77-82
takepod/storage/vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod/storage/vocab.py                              112      7    94%   232-235, 318, 322, 324, 326, 345
---------------------------------------------------------------------------------
TOTAL                                                2129    513    76%

```