### PR TITLE
duplicates and minor issues

### DIFF
--- a/takepod/datasets/croatian_ner_dataset.py
+++ b/takepod/datasets/croatian_ner_dataset.py
@@ -70,14 +70,14 @@ class CroatianNERDataset(dataset.Dataset):
             default fields are used.
 
         **kwargs:
-            scp_user:
+            SCPLargeResource.SCP_USER_KEY:
                 User on the host machine. Not required if the user on the
                 local machine matches the user on the host machine.
-            scp_private_key:
+            SCPLargeResource.SCP_PRIVATE_KEY:
                 Path to the ssh private key eligible to access the host
                 machine. Not required on Unix if the private is in the default
                 location.
-            scp_pass_key:
+            SCPLargeResource.SCP_PASS_KEY:
                 Password for the ssh private key (optional). Can be omitted
                 if the private key is not encrypted.
 

--- a/takepod/datasets/eurovoc_dataset.py
+++ b/takepod/datasets/eurovoc_dataset.py
@@ -9,7 +9,6 @@ from takepod.storage import Field, MultilabelField
 from takepod.storage import Vocab
 from takepod.preproc.stop_words import CROATIAN_EXTENDED
 from takepod.preproc.lemmatizer.croatian_lemmatizer import get_croatian_lemmatizer_hook
-from takepod.storage.downloader import SCPDownloader
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -198,8 +197,7 @@ class EuroVocDataset(dataset.Dataset):
             label = self._crovoc_label_hierarchy[label_id]
             return label.direct_parents
 
-        else:
-            return None
+        return None
 
     def get_all_ancestors(self, label_id):
         """Returns ids of all ancestors of the label with the given label id.
@@ -224,8 +222,7 @@ class EuroVocDataset(dataset.Dataset):
             label = self._crovoc_label_hierarchy[label_id]
             return label.all_ancestors
 
-        else:
-            return None
+        return None
 
     @staticmethod
     def _get_default_fields():

--- a/takepod/examples/dataset_example.py
+++ b/takepod/examples/dataset_example.py
@@ -1,6 +1,6 @@
 """Example how to use simple PauzaHR dataset."""
-import dill
 import logging
+import dill
 
 from takepod.storage.large_resource import LargeResource
 from takepod.datasets.pauza_dataset import PauzaHRDataset

--- a/takepod/models/blcc_model.py
+++ b/takepod/models/blcc_model.py
@@ -1,14 +1,13 @@
 """Module contains deep learning based sequence labelling model.."""
+import numpy as np
 from keras import backend as K
 from keras.layers import Bidirectional, concatenate, Dense, Dropout, Embedding
 from keras.layers import Input, LSTM, TimeDistributed
 from keras.models import Model
 from keras.optimizers import Adadelta, Adagrad, Adam, Nadam, RMSprop, SGD
+
 from takepod.models import AbstractSupervisedModel
-
 from takepod.models.blcc.chain_crf import ChainCRF
-
-import numpy as np
 
 
 class BLCCModel(AbstractSupervisedModel):

--- a/takepod/preproc/tokenizers.py
+++ b/takepod/preproc/tokenizers.py
@@ -64,8 +64,8 @@ def get_tokenizer(tokenizer, language='en'):
     elif tokenizer == "split":
         return str.split
 
-    else:
-        error_msg = f"Wrong value given for the tokenizer: "\
-                    f"{tokenizer}"
-        _LOGGER.error(error_msg)
-        raise ValueError(error_msg)
+    # if tokenizer not found
+    error_msg = f"Wrong value given for the tokenizer: "\
+                f"{tokenizer}"
+    _LOGGER.error(error_msg)
+    raise ValueError(error_msg)

--- a/takepod/preproc/util.py
+++ b/takepod/preproc/util.py
@@ -34,11 +34,25 @@ def capitalize_target_like_source(func):
         if is_lower:
             return target
         else:
-            return _uppercase_target_like_source(source, target)
+            return uppercase_target_like_source(source, target)
     return _wrapper
 
 
-def _uppercase_target_like_source(source, target):
+def uppercase_target_like_source(source, target):
+    """Function uppercases target on the same places source is uppercased.
+
+    Parameters
+    ----------
+    source : str
+        source string from which uppercasing is transfered
+    target : str
+        target string that needs to be uppercased
+
+    Returns
+    -------
+    uppercased_target : str
+        uppercased target string
+    """
     uppercased_target = ''.join([
         target[i].upper()
         if s.isupper() and s.lower() == target[i] else target[i]
@@ -79,9 +93,8 @@ def make_trie(words):
 
 
 def find_word_by_prefix(trie, word):
-    """Searches through a trie data structure and
-    returns an element of the trie is the word
-    is a prefix or exact match of one of the trie elements.
+    """Searches through a trie data structure and returns an element of the trie is the
+    word is a prefix or exact match of one of the trie elements.
     Otherwise returns None
 
     Parameters
@@ -112,6 +125,5 @@ def find_word_by_prefix(trie, word):
     # reached end of the given word
     if TRIE_END_SYMBOL in trie:
         return word
-    else:
-        # partial match in trie found
-        return None
+    # partial match in trie found
+    return None

--- a/takepod/storage/dataset.py
+++ b/takepod/storage/dataset.py
@@ -10,6 +10,7 @@ import copy
 
 from abc import ABC
 from takepod.storage.example_factory import ExampleFactory
+from takepod.storage.field import unpack_fields
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -432,35 +433,6 @@ def create_examples(reader, format, fields, skip_header):
     examples = map(make_example, reader)
 
     return list(examples)
-
-
-def unpack_fields(fields):
-    """Flattens the given fields object into a flat list of fields.
-
-    Parameters
-    ----------
-    fields : (list | dict)
-        List or dict that can contain nested tuples and None as values and
-        column names as keys (dict).
-
-    Returns
-    -------
-    list[Field]
-        A flat list of Fields found in the given 'fields' object.
-    """
-
-    unpacked_fields = list()
-
-    fields = fields.values() if isinstance(fields, dict) else fields
-
-    # None values represent columns that should be ignored
-    for field in filter(lambda f: f is not None, fields):
-        if isinstance(field, tuple):
-            unpacked_fields.extend(field)
-        else:
-            unpacked_fields.append(field)
-
-    return unpacked_fields
 
 
 def check_split_ratio(split_ratio):

--- a/takepod/storage/example_factory.py
+++ b/takepod/storage/example_factory.py
@@ -6,13 +6,25 @@ import json
 import csv
 
 import xml.etree.ElementTree as ET
+from takepod.storage.field import unpack_fields
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class Example(object):
+class Example:
+    """Method models one example with fields that hold
+    (raw, tokenized) values and special fields with "_"
+    at the end that can cache numericalized values"""
 
     def __init__(self, fieldnames):
+        """Method initializes example with given list of
+        fieldnames
+
+        Parameters
+        ----------
+        fieldnames : list(str)
+            list of field names
+        """
         for fieldname in fieldnames:
             setattr(self, fieldname, None)
 
@@ -48,6 +60,13 @@ class ExampleFactory:
         self.fieldnames += [f"{fieldname}_" for fieldname in self.fieldnames]
 
     def create_empty_example(self):
+        """Method creates empty example with field names stored in example factory.
+
+        Returns
+        -------
+        example : Example
+            empty Example instance with initialized field names
+        """
         return Example(self.fieldnames)
 
     def from_dict(self, data):
@@ -216,35 +235,6 @@ def tree_to_list(tree):
         tree represented as list with its label
     """
     return [' '.join(tree.leaves()), tree.label()]
-
-
-def unpack_fields(fields):
-    """Flattens the given fields object into a flat list of fields.
-
-    Parameters
-    ----------
-    fields : (list | dict)
-        List or dict that can contain nested tuples and None as values and
-        column names as keys (dict).
-
-    Returns
-    -------
-    list[Field]
-        A flat list of Fields found in the given 'fields' object.
-    """
-
-    unpacked_fields = list()
-
-    fields = fields.values() if isinstance(fields, dict) else fields
-
-    # None values represent columns that should be ignored
-    for field in filter(lambda f: f is not None, fields):
-        if isinstance(field, tuple):
-            unpacked_fields.extend(field)
-        else:
-            unpacked_fields.append(field)
-
-    return unpacked_fields
 
 
 def _set_example_attributes(example, field, val):

--- a/takepod/storage/field.py
+++ b/takepod/storage/field.py
@@ -9,7 +9,7 @@ from takepod.preproc.tokenizers import get_tokenizer
 _LOGGER = logging.getLogger(__name__)
 
 
-class Field(object):
+class Field:
     """Holds the preprocessing and numericalization logic for a single
     field of a dataset.
     """
@@ -372,10 +372,9 @@ class Field(object):
         if self.custom_numericalize is None and self.use_vocab:
             return self.vocab.numericalize(tokens)
 
-        else:
-            # custom numericalization for non-vocab data
-            # (such as floating point data Fields)
-            return np.array([self.custom_numericalize(tok) for tok in tokens])
+        # custom numericalization for non-vocab data
+        # (such as floating point data Fields)
+        return np.array([self.custom_numericalize(tok) for tok in tokens])
 
     def get_default_value(self):
         """Method obtains default field value for missing data.
@@ -388,8 +387,8 @@ class Field(object):
         """
         if self.sequential:
             return np.empty(0)
-        else:
-            return np.array([np.nan])
+
+        return np.array([np.nan])
 
     def numericalize(self, data):
         """Numericalize the already preprocessed data point based either on
@@ -657,3 +656,32 @@ def numericalize_multihot(tokens, token_indexer, num_of_classes):
     multihot_encoding = np.zeros(num_of_classes, dtype=np.bool)
     multihot_encoding[active_classes] = 1
     return multihot_encoding
+
+
+def unpack_fields(fields):
+    """Flattens the given fields object into a flat list of fields.
+
+    Parameters
+    ----------
+    fields : (list | dict)
+        List or dict that can contain nested tuples and None as values and
+        column names as keys (dict).
+
+    Returns
+    -------
+    list[Field]
+        A flat list of Fields found in the given 'fields' object.
+    """
+
+    unpacked_fields = list()
+
+    fields = fields.values() if isinstance(fields, dict) else fields
+
+    # None values represent columns that should be ignored
+    for field in filter(lambda f: f is not None, fields):
+        if isinstance(field, tuple):
+            unpacked_fields.extend(field)
+        else:
+            unpacked_fields.append(field)
+
+    return unpacked_fields

--- a/takepod/storage/large_resource.py
+++ b/takepod/storage/large_resource.py
@@ -2,6 +2,7 @@
 large resources that should be downloaded should use this module."""
 import os
 import tempfile
+import getpass
 import logging
 from takepod.storage.downloader import SimpleHttpDownloader, SCPDownloader
 from takepod.storage import utility
@@ -197,3 +198,43 @@ class SCPLargeResource(LargeResource):
                                path=download_destination,
                                overwrite=False,
                                **self._scp_config)
+
+
+def init_scp_large_resource_from_kwargs(resource, uri, archive, scp_host, user_dict):
+    """Method initializes scp resource from resource informations and user credentials
+
+    Parameters
+    ----------
+    resource : str
+        resource name, same as LargeResource.RESOURCE_NAME
+    uri : str
+        resource uri, same as LargeResource.URI
+    archive : str
+        archive type, see LargeResource.ARCHIVE
+    scp_host : str
+        remote host adress, see SCPLargeResource.SCP_HOST_KEY
+    user_dict : dict(str, str)
+        user dictionary that may contain scp_user that defines username,
+        scp_private_key that defines path to private key, scp_pass_key that defines user
+        password
+    """
+
+    if SCPLargeResource.SCP_USER_KEY not in user_dict:
+        # if your username is same as the one on the server
+        scp_user = getpass.getuser()
+    else:
+        scp_user = user_dict[SCPLargeResource.SCP_USER_KEY]
+
+    scp_private_key = user_dict.get(SCPLargeResource.SCP_PRIVATE_KEY, None)
+    scp_pass_key = user_dict.get(SCPLargeResource.SCP_PASS_KEY, None)
+
+    config = {
+        LargeResource.URI: uri,
+        LargeResource.RESOURCE_NAME: resource,
+        LargeResource.ARCHIVE: archive,
+        SCPLargeResource.SCP_HOST_KEY: scp_host,
+        SCPLargeResource.SCP_USER_KEY: scp_user,
+        SCPLargeResource.SCP_PRIVATE_KEY: scp_private_key,
+        SCPLargeResource.SCP_PASS_KEY: scp_pass_key
+    }
+    SCPLargeResource(**config)

--- a/takepod/storage/vocab.py
+++ b/takepod/storage/vocab.py
@@ -8,6 +8,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class VocabDict(dict):
+    """Vocab dictionary class that is used like default dict but without adding missing
+    key to the dictionary."""
     def __init__(self, default_factory=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._default_factory = default_factory

--- a/test/dataload/test_eurovoc.py
+++ b/test/dataload/test_eurovoc.py
@@ -6,7 +6,7 @@ import pytest
 from mock import patch
 
 from takepod.dataload.eurovoc import EuroVocLoader, Label, LabelRank
-from takepod.storage.large_resource import LargeResource
+from takepod.storage.large_resource import LargeResource, SCPLargeResource
 
 EUROVOC_LABELS = r"""
 <DATABASE_THS>
@@ -458,7 +458,7 @@ def test_loading_dataset_with_invalid_labels():
         path = create_mock_dataset(invalid_labels=True)
         with patch.object(LargeResource, "BASE_RESOURCE_DIR", path):
             loader = EuroVocLoader()
-            eurovoc_labels, crovoc_labels, mappings, documents = loader.load_dataset()
+            loader.load_dataset()
 
 
 def test_loading_dataset_with_non_existing_thesaurus():
@@ -466,16 +466,16 @@ def test_loading_dataset_with_non_existing_thesaurus():
     path = create_mock_dataset(non_existing_thesaurus=True)
     with patch.object(LargeResource, "BASE_RESOURCE_DIR", path):
         loader = EuroVocLoader()
-        eurovoc_labels, crovoc_labels, mappings, documents = loader.load_dataset()
+        eurovoc_labels, _, _, _ = loader.load_dataset()
 
         label = eurovoc_labels[3]
         assert label.thesaurus is None
 
 
 def mock_download(self):
-    assert self.config['scp_user'] == 'username'
-    assert self.config['scp_priv'] == 'private_key'
-    assert self.config['scp_pass'] == 'pass'
+    assert self.config[SCPLargeResource.SCP_USER_KEY] == 'username'
+    assert self.config[SCPLargeResource.SCP_PRIVATE_KEY] == 'private_key'
+    assert self.config[SCPLargeResource.SCP_PASS_KEY] == 'pass'
 
 
 @patch.object(LargeResource, '_download_unarchive', mock_download)
@@ -485,8 +485,8 @@ def test_download_dataset_using_scp():
     with patch.object(LargeResource, "BASE_RESOURCE_DIR", base):
         assert os.path.exists(LargeResource.BASE_RESOURCE_DIR)
 
-        loader = EuroVocLoader(
-            scp_user='username',
-            scp_private_key='private_key',
-            scp_pass_key='pass'
-        )
+        EuroVocLoader(**{
+            SCPLargeResource.SCP_USER_KEY: 'username',
+            SCPLargeResource.SCP_PRIVATE_KEY: 'private_key',
+            SCPLargeResource.SCP_PASS_KEY: 'pass'
+        })

--- a/test/preproc/test_lemmatizer.py
+++ b/test/preproc/test_lemmatizer.py
@@ -133,6 +133,7 @@ def mock_lemmatizer(molex14_lemma2word, molex14_word2lemma):
     with mock.patch(
             'takepod.storage.large_resource.SCPLargeResource.__init__'
     ) as mock_scp:
+        mock_scp.return_value = None
         mock_scp.SCP_HOST_KEY = "scp_host"
         mock_scp.SCP_USER_KEY = "scp_user"
         mock_scp.SCP_PASS_KEY = "scp_pass"


### PR DESCRIPTION
```
----------- coverage: platform win32, python 3.6.2-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod\__init__.py                                    15      0   100%
takepod\dataload\__init__.py                            0      0   100%
takepod\dataload\eurovoc.py                           183      2    99%   14-15
takepod\dataload\ner_croatian.py                       62      0   100%
takepod\datasets\__init__.py                            3      0   100%
takepod\datasets\catacx_comments_dataset.py            40      4    90%   53-66
takepod\datasets\catacx_dataset.py                     56      3    95%   28-29, 48
takepod\datasets\croatian_ner_dataset.py               38      0   100%
takepod\datasets\eurovoc_dataset.py                    92      0   100%
takepod\datasets\imdb_sentiment_dataset.py             49      0   100%
takepod\datasets\pauza_dataset.py                      37      0   100%
takepod\examples\__init__.py                            0      0   100%
takepod\examples\dataset_example.py                    14     14     0%   2-28
takepod\examples\model_example.py                      49     21    57%   62-78, 85-87, 95-108, 114-115
takepod\examples\ner_example.py                        92     92     0%   3-196
takepod\examples\vectors_example.py                    15     15     0%   3-25
takepod\metrics\__init__.py                             2      0   100%
takepod\metrics\metrics.py                             10      3    70%   8-9, 21
takepod\models\__init__.py                              2      0   100%
takepod\models\base_model.py                           12      4    67%   36, 55, 78, 104
takepod\models\base_trainer.py                          6      1    83%   29
takepod\models\blcc\__init__.py                         0      0   100%
takepod\models\blcc\chain_crf.py                      171    171     0%   6-409
takepod\models\blcc_model.py                           93     93     0%   2-217
takepod\models\fc_model.py                             16      2    88%   9-10
takepod\models\simple_trainers.py                      17      0   100%
takepod\models\svm_model.py                            15      2    87%   9-10
takepod\preproc\__init__.py                             4      0   100%
takepod\preproc\lemmatizer\__init__.py                  2      0   100%
takepod\preproc\lemmatizer\croatian_lemmatizer.py      63      0   100%
takepod\preproc\stemmer\__init__.py                     2      0   100%
takepod\preproc\stemmer\croatian_stemmer.py            46      0   100%
takepod\preproc\stop_words.py                          13      0   100%
takepod\preproc\tokenizers.py                          21      0   100%
takepod\preproc\util.py                                35      0   100%
takepod\storage\__init__.py                             9      0   100%
takepod\storage\dataset.py                            296      4    99%   844, 943-946
takepod\storage\downloader.py                          54     15    72%   45, 113-132, 160
takepod\storage\example_factory.py                     67     14    79%   120-126, 184-185, 211-221, 237
takepod\storage\field.py                              169      3    98%   415-417
takepod\storage\iterator.py                           159     13    92%   475-480, 483-487, 525, 574, 581, 602-606, 609
takepod\storage\large_resource.py                      70      2    97%   110, 144
takepod\storage\tfidf.py                               73      0   100%
takepod\storage\utility.py                             28      9    68%   53-55, 77-82
takepod\storage\vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod\storage\vocab.py                              122      7    94%   248-251, 334, 338, 340, 342, 361
---------------------------------------------------------------------------------
TOTAL                                                2477    513    79%


========================= 405 passed in 7.08 seconds ==========================
```