### PR TITLE
Bow

### DIFF
--- a/takepod/storage/tfidf.py
+++ b/takepod/storage/tfidf.py
@@ -181,7 +181,7 @@ class CountVectorizer:
         """
         self._check_fitted()
         is_tokens_tensor = kwargs['is_tokens_tensor'] if 'is_tokens_tensor' in kwargs\
-                                                      else True
+            else True
         field = kwargs['field'] if 'field' in kwargs else None
 
         if examples is None:

--- a/test/storage/test_tfidf.py
+++ b/test/storage/test_tfidf.py
@@ -211,6 +211,26 @@ def test_count_vectorizer_transform_no_fit():
         count_vectorizer.transform(examples=[[1, 1, 1, 1, 1, 0, 0, 0, 0]])
 
 
+def test_count_vectorizer_transform_tokens_tensor():
+    vocab = Vocab(specials=())
+    for i in DATA:
+        vocab += i.split(" ")
+    vocab.finalize()
+    count_vectorizer = CountVectorizer(vocab=vocab)
+    count_vectorizer.fit(dataset=None, field=None)
+
+    numericalized_data = get_numericalized_data(data=DATA, vocab=vocab)
+    bow = count_vectorizer.transform(numericalized_data).todense()
+    expected = np.array([
+        [1, 1, 1, 1, 1, 0, 0, 0, 0],
+        [1, 1, 1, 2, 0, 1, 0, 0, 0],
+        [1, 1, 1, 0, 0, 0, 1, 1, 1],
+        [1, 1, 1, 1, 1, 0, 0, 0, 0]])
+    assert np.allclose(a=bow,
+                       b=expected,
+                       rtol=0, atol=1.e-6)
+
+
 @pytest.mark.usefixtures("tabular_dataset")
 def test_count_vectorizer_examples_none(tabular_dataset):
     tabular_dataset.finalize_fields()


### PR DESCRIPTION
```
----------- coverage: platform win32, python 3.6.2-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod\__init__.py                                    15      0   100%
takepod\dataload\__init__.py                            0      0   100%
takepod\dataload\eurovoc.py                           183      2    99%   14-15
takepod\dataload\ner_croatian.py                       62      0   100%
takepod\datasets\__init__.py                            4      0   100%
takepod\datasets\catacx_comments_dataset.py            40      4    90%   53-66
takepod\datasets\catacx_dataset.py                     56      3    95%   28-29, 48
takepod\datasets\croatian_ner_dataset.py               38      0   100%
takepod\datasets\eurovoc_dataset.py                    92      0   100%
takepod\datasets\imdb_sentiment_dataset.py             49      0   100%
takepod\datasets\pauza_dataset.py                      37      0   100%
takepod\examples\__init__.py                            0      0   100%
takepod\examples\dataset_example.py                    14     14     0%   2-28
takepod\examples\model_example.py                      49     21    57%   62-78, 85-87, 95-108, 114-115
takepod\examples\ner_example.py                        92     92     0%   3-196
takepod\examples\tfidf_svm_example.py                  32     32     0%   2-56
takepod\examples\vectors_example.py                    15     15     0%   3-25
takepod\metrics\__init__.py                             2      0   100%
takepod\metrics\metrics.py                             10      3    70%   8-9, 21
takepod\models\__init__.py                              3      0   100%
takepod\models\base_model.py                           12      4    67%   36, 55, 78, 104
takepod\models\base_trainer.py                          6      1    83%   29
takepod\models\blcc\__init__.py                         0      0   100%
takepod\models\blcc\chain_crf.py                      171    171     0%   6-409
takepod\models\blcc_model.py                           93     93     0%   2-217
takepod\models\fc_model.py                             16      2    88%   9-10
takepod\models\simple_trainers.py                      17      0   100%
takepod\models\svm_model.py                            18      3    83%   9-10, 31
takepod\preproc\__init__.py                             4      0   100%
takepod\preproc\lemmatizer\__init__.py                  2      0   100%
takepod\preproc\lemmatizer\croatian_lemmatizer.py      63      0   100%
takepod\preproc\stemmer\__init__.py                     2      0   100%
takepod\preproc\stemmer\croatian_stemmer.py            46      0   100%
takepod\preproc\stop_words.py                          13      0   100%
takepod\preproc\tokenizers.py                          21      0   100%
takepod\preproc\util.py                                35      0   100%
takepod\storage\__init__.py                             9      0   100%
takepod\storage\dataset.py                            300      4    99%   856, 955-958
takepod\storage\downloader.py                          54     15    72%   45, 113-132, 160
takepod\storage\example_factory.py                     70     14    80%   120-126, 184-185, 211-221, 237
takepod\storage\field.py                              222      6    97%   153, 174, 589-591, 721
takepod\storage\iterator.py                           174     13    93%   515-520, 523-527, 565, 614, 622, 643-647, 650
takepod\storage\large_resource.py                      70      2    97%   110, 144
takepod\storage\tfidf.py                               99      9    91%   196-200, 261-264, 266-268
takepod\storage\utility.py                             28      9    68%   53-55, 77-82
takepod\storage\vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod\storage\vocab.py                              122      7    94%   248-251, 334, 338, 340, 342, 361
---------------------------------------------------------------------------------
TOTAL                                                2615    558    79%


========================= 419 passed in 8.57 seconds ====================
```