### PR TITLE
Added check to skip a Yake test if Yake is not installed

### DIFF
--- a/test/preproc/test_yake.py
+++ b/test/preproc/test_yake.py
@@ -70,6 +70,7 @@ def test_yake_en_nondefault_wrapper_output(keyword_data):
 
 @pytest.mark.usefixtures("keyword_data")
 def test_yake_en_default_output(keyword_data):
+    pytest.importorskip('yake')
     yake = YAKE()
     output_kws = yake(keyword_data["text"])
 


### PR DESCRIPTION
```
platform linux -- Python 3.6.8, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/ivans/Repositories/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 423 items                                                                                                                               

test/dataload/test_eurovoc.py ...ssssssss                                                                                                   [  2%]
test/dataload/test_ner_croatian.py ......                                                                                                   [  4%]
test/datasets/test_catacx_comments_dataset.py .                                                                                             [  4%]
test/datasets/test_catacx_dataset.py ..                                                                                                     [  4%]
test/datasets/test_croatian_ner_dataset.py ...                                                                                              [  5%]
test/datasets/test_eurovoc_dataset.py .............                                                                                         [  8%]
test/datasets/test_imdb_dataset.py ...                                                                                                      [  9%]
test/datasets/test_pauzahr_dataset.py ...                                                                                                   [  9%]
test/examples/test_model_example.py .......                                                                                                 [ 11%]
test/metrics/test_metrics.py .                                                                                                              [ 11%]
test/models/test_fc_model.py .                                                                                                              [ 12%]
test/models/test_simple_trainers.py ...                                                                                                     [ 12%]
test/models/test_svm_model.py .                                                                                                             [ 13%]
test/preproc/test_lemmatizer.py .................                                                                                           [ 17%]
test/preproc/test_stemmer.py .........                                                                                                      [ 19%]
test/preproc/test_stop_words.py ....                                                                                                        [ 20%]
test/preproc/test_util.py ......                                                                                                            [ 21%]
test/preproc/test_yake.py sss                                                                                                               [ 22%]
test/storage/test_dataset.py ...........................................................................................                    [ 43%]
test/storage/test_downloader.py ...........                                                                                                 [ 46%]
test/storage/test_example_factory.py ....................................                                                                   [ 54%]
test/storage/test_field.py ................................................................                                                 [ 69%]
test/storage/test_iterator.py ...................................                                                                           [ 78%]
test/storage/test_large_resource.py .........                                                                                               [ 80%]
test/storage/test_tfidf.py ..................                                                                                               [ 84%]
test/storage/test_vectorizer.py ............................                                                                                [ 91%]
test/storage/test_vocab.py .....................................                                                                            [100%]

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod/__init__.py                                    15      0   100%
takepod/dataload/__init__.py                            0      0   100%
takepod/dataload/eurovoc.py                           183    136    26%   113, 132-155, 181-249, 268-315, 332-344, 358-370, 385-414, 433-453, 468-502, 520
takepod/dataload/ner_croatian.py                       62      0   100%
takepod/datasets/__init__.py                            4      0   100%
takepod/datasets/catacx_comments_dataset.py            40      4    90%   53-66
takepod/datasets/catacx_dataset.py                     56      3    95%   28-29, 48
takepod/datasets/croatian_ner_dataset.py               38      0   100%
takepod/datasets/eurovoc_dataset.py                    92      0   100%
takepod/datasets/imdb_sentiment_dataset.py             49      0   100%
takepod/datasets/pauza_dataset.py                      37      0   100%
takepod/examples/__init__.py                            0      0   100%
takepod/examples/dataset_example.py                    14     14     0%   2-28
takepod/examples/keywords_example.py                   19     19     0%   1-73
takepod/examples/model_example.py                      49     21    57%   62-78, 85-87, 95-108, 114-115
takepod/examples/ner_example.py                        92     92     0%   3-196
takepod/examples/tfidf_svm_example.py                  32     32     0%   2-56
takepod/examples/vectors_example.py                    15     15     0%   3-25
takepod/metrics/__init__.py                             2      0   100%
takepod/metrics/metrics.py                             10      3    70%   8-9, 21
takepod/models/__init__.py                              3      0   100%
takepod/models/base_model.py                           12      4    67%   36, 55, 78, 104
takepod/models/base_trainer.py                          6      1    83%   29
takepod/models/blcc/__init__.py                         0      0   100%
takepod/models/blcc/chain_crf.py                      171    171     0%   6-409
takepod/models/blcc_model.py                           93     93     0%   2-217
takepod/models/fc_model.py                             16      2    88%   9-10
takepod/models/simple_trainers.py                      17      0   100%
takepod/models/svm_model.py                            18      3    83%   9-10, 31
takepod/preproc/__init__.py                             4      0   100%
takepod/preproc/lemmatizer/__init__.py                  2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py      63      0   100%
takepod/preproc/stemmer/__init__.py                     2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py            46      0   100%
takepod/preproc/stop_words.py                          13      0   100%
takepod/preproc/tokenizers.py                          21      0   100%
takepod/preproc/util.py                                35      0   100%
takepod/preproc/yake.py                                14      4    71%   40, 51, 65-66
takepod/storage/__init__.py                             9      0   100%
takepod/storage/dataset.py                            300      4    99%   856, 955-958
takepod/storage/downloader.py                          54     15    72%   45, 113-132, 160
takepod/storage/example_factory.py                     70     14    80%   120-126, 184-185, 211-221, 237
takepod/storage/field.py                              222      6    97%   153, 174, 589-591, 721
takepod/storage/iterator.py                           174     13    93%   515-520, 523-527, 565, 614, 622, 643-647, 650
takepod/storage/large_resource.py                      70      2    97%   110, 144
takepod/storage/tfidf.py                               99      9    91%   197-201, 262-265, 267-269
takepod/storage/utility.py                             28      9    68%   53-55, 77-82
takepod/storage/vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod/storage/vocab.py                              122      7    94%   248-251, 334, 338, 340, 342, 361
---------------------------------------------------------------------------------
TOTAL                                                2648    715    73%

```