### PR TITLE
MultilabelSVM update

### DIFF
--- a/takepod/models/eurovoc_models/multilabel_svm.py
+++ b/takepod/models/eurovoc_models/multilabel_svm.py
@@ -186,6 +186,9 @@ class MultilabelSVM(AbstractSupervisedModel):
                                "instance.")
         return self._missing_indexes
 
+    def reset(self, **kwargs):
+        raise NotImplementedError("Reset not yet implemented for this model.")
+
 
 def get_label_matrix(Y):
     """Takes the target fields returned by the EuroVoc iterator and returns the EuroVoc


### PR DESCRIPTION
Made MultilabelSVM conform to the new model interface.
This is a temp fix.

```
platform linux -- Python 3.6.8, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/ivans/Repositories/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 443 items                                                                                                                     

test/dataload/test_cornel_movie_dialogs.py .                                                                                      [  0%]
test/dataload/test_eurovoc.py ...ssssssss.                                                                                        [  2%]
test/dataload/test_ner_croatian.py ......                                                                                         [  4%]
test/datasets/test_catacx_comments_dataset.py .                                                                                   [  4%]
test/datasets/test_catacx_dataset.py ..                                                                                           [  4%]
test/datasets/test_croatian_ner_dataset.py ...                                                                                    [  5%]
test/datasets/test_eurovoc_dataset.py .............                                                                               [  8%]
test/datasets/test_imdb_dataset.py ...                                                                                            [  9%]
test/datasets/test_pauzahr_dataset.py ...                                                                                         [  9%]
test/examples/test_model_example.py .......                                                                                       [ 11%]
test/metrics/test_metrics.py .                                                                                                    [ 11%]
test/models/test_default_batch_transform_functions.py ..                                                                          [ 12%]
test/models/test_experiment.py ..                                                                                                 [ 12%]
test/models/test_fc_model.py .                                                                                                    [ 12%]
test/models/test_simple_trainers.py ...                                                                                           [ 13%]
test/models/test_svm_model.py .                                                                                                   [ 13%]
test/models/eurovoc_models/test_multilabel_svm.py ..........                                                                      [ 16%]
test/preproc/test_lemmatizer.py .................                                                                                 [ 19%]
test/preproc/test_stemmer.py .........                                                                                            [ 21%]
test/preproc/test_stop_words.py ....                                                                                              [ 22%]
test/preproc/test_util.py ......                                                                                                  [ 24%]
test/preproc/test_yake.py ...                                                                                                     [ 24%]
test/storage/test_dataset.py ...............................................................................................      [ 46%]
test/storage/test_downloader.py ...........                                                                                       [ 48%]
test/storage/test_example_factory.py ....................................                                                         [ 56%]
test/storage/test_field.py ................................................................                                       [ 71%]
test/storage/test_iterator.py ...................................                                                                 [ 79%]
test/storage/test_large_resource.py .........                                                                                     [ 81%]
test/storage/test_tfidf.py ..................                                                                                     [ 85%]
test/storage/test_vectorizer.py ............................                                                                      [ 91%]
test/storage/test_vocab.py .....................................                                                                  [100%]

----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                                Stmts   Miss  Cover   Missing
---------------------------------------------------------------------------------
takepod/__init__.py                                    15      0   100%
takepod/dataload/__init__.py                            0      0   100%
takepod/dataload/cornel_movie_dialogs.py               57      2    96%   13-14
takepod/dataload/eurovoc.py                           192    136    29%   115, 134-157, 183-251, 270-317, 334-346, 360-372, 387-416, 435-455, 470-504, 522
takepod/dataload/ner_croatian.py                       62      0   100%
takepod/datasets/__init__.py                            4      0   100%
takepod/datasets/catacx_comments_dataset.py            40      4    90%   53-66
takepod/datasets/catacx_dataset.py                     56      3    95%   28-29, 48
takepod/datasets/croatian_ner_dataset.py               38      0   100%
takepod/datasets/eurovoc_dataset.py                    92      0   100%
takepod/datasets/imdb_sentiment_dataset.py             49      0   100%
takepod/datasets/pauza_dataset.py                      37      0   100%
takepod/examples/__init__.py                            0      0   100%
takepod/examples/dataset_example.py                    14     14     0%   2-28
takepod/examples/experiment_example.py                 46     46     0%   3-100
takepod/examples/keywords_example.py                   19     19     0%   1-73
takepod/examples/model_example.py                      49     21    57%   62-77, 84-86, 94-107, 113-114
takepod/examples/ner_example.py                        92     92     0%   3-195
takepod/examples/tfidf_svm_example.py                  32     32     0%   2-55
takepod/examples/vectors_example.py                    15     15     0%   3-25
takepod/metrics/__init__.py                             2      0   100%
takepod/metrics/metrics.py                             10      3    70%   8-9, 21
takepod/models/__init__.py                              5      0   100%
takepod/models/base_model.py                           14      5    64%   36, 55, 67, 90, 116
takepod/models/base_trainer.py                          5      1    80%   24
takepod/models/batch_transform_functions.py            14      0   100%
takepod/models/blcc/__init__.py                         0      0   100%
takepod/models/blcc/chain_crf.py                      171    171     0%   6-409
takepod/models/blcc_model.py                           95     95     0%   2-220
takepod/models/eurovoc_models/multilabel_svm.py       111     54    51%   190, 253-322
takepod/models/experiment.py                           44      1    98%   57
takepod/models/fc_model.py                             18      2    89%   9-10
takepod/models/simple_trainers.py                      13      0   100%
takepod/models/svm_model.py                            20      3    85%   9-10, 34
takepod/preproc/__init__.py                             4      0   100%
takepod/preproc/lemmatizer/__init__.py                  2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py      63      0   100%
takepod/preproc/stemmer/__init__.py                     2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py            46      0   100%
takepod/preproc/stop_words.py                          13      0   100%
takepod/preproc/tokenizers.py                          21      0   100%
takepod/preproc/util.py                                35      0   100%
takepod/preproc/yake.py                                14      2    86%   7-8
takepod/storage/__init__.py                             9      0   100%
takepod/storage/dataset.py                            316      7    98%   431-434, 1002, 1101-1104
takepod/storage/downloader.py                          54     15    72%   45, 113-132, 160
takepod/storage/example_factory.py                     70     14    80%   120-126, 184-185, 211-221, 237
takepod/storage/field.py                              222      6    97%   153, 174, 589-591, 721
takepod/storage/iterator.py                           193     22    89%   99, 373, 377-378, 381, 384-388, 572-577, 580-584, 622, 671, 679, 700-704, 707
takepod/storage/large_resource.py                      70      2    97%   110, 144
takepod/storage/tfidf.py                               99      9    91%   197-201, 262-265, 267-269
takepod/storage/utility.py                             28      9    68%   53-55, 77-82
takepod/storage/vectorizer.py                         155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 490-502
takepod/storage/vocab.py                              122      7    94%   248-251, 334, 338, 340, 342, 361
takepod/validation/__init__.py                          2      0   100%
takepod/validation/validation.py                        7      3    57%   26-28
---------------------------------------------------------------------------------
TOTAL                                                2978    834    72%

```