### PR TITLE
Iris dataset

### DIFF
--- a/takepod/datasets/iris_dataset.py
+++ b/takepod/datasets/iris_dataset.py
@@ -1,0 +1,51 @@
+from sklearn.datasets import load_iris
+
+from takepod.datasets import Dataset
+from takepod.storage import ExampleFactory, Field
+
+
+class IrisDataset(Dataset):
+    """This is the classic Iris dataset. This is perhaps the best known database to be
+    found in the pattern recognition literature.
+
+    The fields of this dataset are:
+        sepal_length - float
+        sepal_width - float
+        petal_length - float
+        petal_width - float
+        species - int, specifying iris species
+    """
+
+    def __init__(self):
+        """Loads the Iris dataset.
+        """
+        x, y = load_iris(True)
+
+        fields = IrisDataset._get_default_fields()
+        example_factory = ExampleFactory(fields)
+
+        data = ((*x_, y_) for x_, y_ in zip(x, y))
+
+        examples = list(map(example_factory.from_list, data))
+        super().__init__(examples, fields)
+
+    @staticmethod
+    def _get_default_fields():
+        def identity(x):
+            return x
+
+        sepal_len_field = Field("sepal_length", tokenize=False,
+                                custom_numericalize=identity)
+        sepal_width_field = Field("sepal_width", tokenize=False,
+                                  custom_numericalize=identity)
+        petal_len_field = Field("petal_length", tokenize=False,
+                                custom_numericalize=identity)
+        petal_width_field = Field("petal_width", tokenize=False,
+                                  custom_numericalize=identity)
+
+        species_field = Field("species", tokenize=False,
+                              custom_numericalize=identity, is_target=True)
+
+        return sepal_len_field, sepal_width_field, \
+            petal_len_field, petal_width_field, \
+            species_field

--- a/test/datasets/test_iris_dataset.py
+++ b/test/datasets/test_iris_dataset.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+def test_iris_dataset():
+    sklearn_datasets = pytest.importorskip("sklearn.datasets")
+    from takepod.datasets.iris_dataset import IrisDataset
+
+    iris_ds = IrisDataset()
+
+    x, y = sklearn_datasets.load_iris(True)
+
+    assert len(iris_ds) == len(x)
+    for i in range(0, len(x), 30):
+        sepal_len, sepal_width, petal_len, petal_width = x[i]
+        species = y[i]
+
+        ex = iris_ds[i]
+
+        assert ex.sepal_length[0] == sepal_len
+        assert ex.sepal_width[0] == sepal_width
+        assert ex.petal_length[0] == petal_len
+        assert ex.petal_width[0] == petal_width
+        assert ex.species[0] == species


### PR DESCRIPTION
Ported the classic Iris dataset from sklearn. Should be useful as a simple demo dataset.
```
=================================== test session starts ===================================
platform linux -- Python 3.6.7, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/ivan/Repositories/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 448 items                                                                       

test/dataload/test_cornel_movie_dialogs.py .                                        [  0%]
test/dataload/test_eurovoc.py ...ssssssss.                                          [  2%]
test/dataload/test_ner_croatian.py ......                                           [  4%]
test/datasets/test_catacx_comments_dataset.py .                                     [  4%]
test/datasets/test_catacx_dataset.py ..                                             [  4%]
test/datasets/test_cornell_movie_dialogs_dataset.py ...                             [  5%]
test/datasets/test_croatian_ner_dataset.py ...                                      [  6%]
test/datasets/test_eurovoc_dataset.py .............                                 [  9%]
test/datasets/test_imdb_dataset.py ...                                              [  9%]
test/datasets/test_iris_dataset.py .                                                [ 10%]
test/datasets/test_pauzahr_dataset.py ...                                           [ 10%]
test/examples/test_model_example.py .......                                         [ 12%]
test/metrics/test_metrics.py .                                                      [ 12%]
test/models/test_default_batch_transform_functions.py ..                            [ 12%]
test/models/test_experiment.py ..                                                   [ 13%]
test/models/test_fc_model.py .                                                      [ 13%]
test/models/test_simple_trainers.py ...                                             [ 14%]
test/models/test_svm_model.py .                                                     [ 14%]
test/models/eurovoc_models/test_multilabel_svm.py ..........                        [ 16%]
test/preproc/test_lemmatizer.py .................                                   [ 20%]
test/preproc/test_stemmer.py .........                                              [ 22%]
test/preproc/test_stop_words.py ....                                                [ 23%]
test/preproc/test_util.py ......                                                    [ 24%]
test/preproc/test_yake.py sss                                                       [ 25%]
test/storage/test_dataset.py ...................................................... [ 37%]
..........................................                                          [ 46%]
test/storage/test_downloader.py ...........                                         [ 49%]
test/storage/test_example_factory.py ....................................           [ 57%]
test/storage/test_field.py ........................................................ [ 69%]
........                                                                            [ 71%]
test/storage/test_iterator.py ...................................                   [ 79%]
test/storage/test_large_resource.py .........                                       [ 81%]
test/storage/test_tfidf.py ..................                                       [ 85%]
test/storage/test_vectorizer.py ............................                        [ 91%]
test/storage/test_vocab.py .....................................                    [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                                     Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------
takepod/__init__.py                                         15      0   100%
takepod/dataload/__init__.py                                 0      0   100%
takepod/dataload/cornell_movie_dialogs.py                   58      2    97%   13-14
takepod/dataload/eurovoc.py                                198    142    28%   115, 134-157, 183-251, 270-319, 336-348, 362-374, 389-418, 437-458, 473-509, 527
takepod/dataload/ner_croatian.py                            62      0   100%
takepod/datasets/__init__.py                                10      0   100%
takepod/datasets/dataset.py                                161      3    98%   430-433
takepod/datasets/hierarhical_dataset.py                    121      4    97%   215, 310-313
takepod/datasets/impl/__init__.py                            6      0   100%
takepod/datasets/impl/catacx_comments_dataset.py            40      4    90%   53-66
takepod/datasets/impl/catacx_dataset.py                     57      3    95%   28-29, 48
takepod/datasets/impl/cornell_movie_dialogs_dataset.py      40      0   100%
takepod/datasets/impl/croatian_ner_dataset.py               39      0   100%
takepod/datasets/impl/eurovoc_dataset.py                    93      0   100%
takepod/datasets/impl/imdb_sentiment_dataset.py             52      0   100%
takepod/datasets/impl/pauza_dataset.py                      40      0   100%
takepod/datasets/iris_dataset.py                            20      1    95%   35
takepod/datasets/iterator.py                               194     22    89%   100, 374, 378-379, 382, 385-389, 573-577, 580-583, 621, 670, 678, 699-703, 706
takepod/datasets/tabular_dataset.py                         40      0   100%
takepod/examples/__init__.py                                 0      0   100%
takepod/examples/dataset_example.py                         14     14     0%   2-28
takepod/examples/experiment_example.py                      46     46     0%   3-100
takepod/examples/keywords_example.py                        18     18     0%   2-73
takepod/examples/model_example.py                           50     21    58%   63-78, 85-87, 95-108, 114-115
takepod/examples/ner_example.py                             93     93     0%   3-196
takepod/examples/tfidf_svm_example.py                       33     33     0%   2-56
takepod/examples/vectors_example.py                         15     15     0%   3-25
takepod/metrics/__init__.py                                  2      0   100%
takepod/metrics/metrics.py                                  10      3    70%   8-9, 21
takepod/models/__init__.py                                   8      0   100%
takepod/models/batch_transform_functions.py                 14      0   100%
takepod/models/experiment.py                                45      1    98%   60
takepod/models/impl/__init__.py                              4      0   100%
takepod/models/impl/blcc/__init__.py                         0      0   100%
takepod/models/impl/blcc/chain_crf.py                      176    176     0%   5-416
takepod/models/impl/blcc_model.py                          100    100     0%   2-228
takepod/models/impl/eurovoc_models/__init__.py               2      0   100%
takepod/models/impl/eurovoc_models/multilabel_svm.py       112     54    52%   190, 253-322
takepod/models/impl/fc_model.py                             18      2    89%   9-10
takepod/models/impl/simple_trainers.py                      13      0   100%
takepod/models/impl/svm_model.py                            20      3    85%   9-10, 34
takepod/models/model.py                                     14      5    64%   36, 55, 67, 90, 116
takepod/models/trainer.py                                    5      1    80%   24
takepod/preproc/__init__.py                                  4      0   100%
takepod/preproc/lemmatizer/__init__.py                       2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py           63      0   100%
takepod/preproc/stemmer/__init__.py                          2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py                 46      0   100%
takepod/preproc/stop_words.py                               13      0   100%
takepod/preproc/tokenizers.py                               21      0   100%
takepod/preproc/util.py                                     35      0   100%
takepod/preproc/yake.py                                     14      4    71%   41, 52, 66-67
takepod/storage/__init__.py                                  8      0   100%
takepod/storage/example_factory.py                          75     18    76%   32-35, 151-157, 215-216, 242-252, 268
takepod/storage/field.py                                   222      6    97%   153, 174, 587-589, 719
takepod/storage/resources/__init__.py                        0      0   100%
takepod/storage/resources/downloader.py                     54     15    72%   45, 113-132, 160
takepod/storage/resources/large_resource.py                 70      2    97%   110, 144
takepod/storage/resources/utility.py                        28      9    68%   53-55, 77-82
takepod/storage/vectorizers/__init__.py                      0      0   100%
takepod/storage/vectorizers/tfidf.py                        99      9    91%   197-201, 262-265, 267-269
takepod/storage/vectorizers/vectorizer.py                  155     19    88%   86, 109, 135, 154, 165, 184, 317-320, 332-336, 489-501
takepod/storage/vocab.py                                   122      7    94%   248-251, 334, 338, 340, 342, 361
takepod/validation/__init__.py                               2      0   100%
takepod/validation/validation.py                             7      3    57%   26-28
--------------------------------------------------------------------------------------
TOTAL                                                     3100    858    72%
```