### PR TITLE
Fixed issue #129 

### DIFF
--- a/takepod/storage/field.py
+++ b/takepod/storage/field.py
@@ -455,7 +455,7 @@ class Field:
 
         if self.store_as_tokenized:
             # Store data as tokens
-            _, tokens = self._run_posttokenization_hooks(None, data)
+            data, tokens = None, data
 
         else:
             # Preprocess the raw input


### PR DESCRIPTION
Fixed calling posttokenization hooks twice.
fixes issue #129.
```
platform linux -- Python 3.6.7, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
rootdir: /home/ivan/Repositories/takepod, inifile:
plugins: mock-1.10.1, cov-2.6.0
collected 453 items                                                          

test/dataload/test_cornel_movie_dialogs.py .                           [  0%]
test/dataload/test_eurovoc.py ...ssssssss.                             [  2%]
test/dataload/test_ner_croatian.py ......                              [  4%]
test/datasets/test_catacx_comments_dataset.py .                        [  4%]
test/datasets/test_catacx_dataset.py ..                                [  4%]
test/datasets/test_cornell_movie_dialogs_dataset.py ...                [  5%]
test/datasets/test_croatian_ner_dataset.py ...                         [  6%]
test/datasets/test_eurovoc_dataset.py .............                    [  9%]
test/datasets/test_imdb_dataset.py ...                                 [  9%]
test/datasets/test_iris_dataset.py .                                   [  9%]
test/datasets/test_pauzahr_dataset.py ...                              [ 10%]
test/examples/test_model_example.py ......                             [ 11%]
test/metrics/test_metrics.py .                                         [ 12%]
test/models/test_default_batch_transform_functions.py ..               [ 12%]
test/models/test_experiment.py ...                                     [ 13%]
test/models/test_fc_model.py .                                         [ 13%]
test/models/test_simple_trainers.py ...                                [ 14%]
test/models/test_svm_model.py .                                        [ 14%]
test/models/test_transformers.py ..                                    [ 14%]
test/models/eurovoc_models/test_multilabel_svm.py ..........           [ 16%]
test/pipeline/test_pipeline.py .                                       [ 17%]
test/preproc/test_lemmatizer.py .................                      [ 20%]
test/preproc/test_stemmer.py .........                                 [ 22%]
test/preproc/test_stop_words.py ....                                   [ 23%]
test/preproc/test_util.py ......                                       [ 25%]
test/preproc/test_yake.py sss                                          [ 25%]
test/storage/test_dataset.py ......................................... [ 34%]
.......................................................                [ 47%]
test/storage/test_downloader.py ...........                            [ 49%]
test/storage/test_example_factory.py ................................. [ 56%]
....                                                                   [ 57%]
test/storage/test_field.py ........................................... [ 67%]
......................                                                 [ 71%]
test/storage/test_iterator.py ...................................      [ 79%]
test/storage/test_large_resource.py .........                          [ 81%]
test/storage/test_tfidf.py ..................                          [ 85%]
test/storage/test_vectorizer.py ............................           [ 91%]
test/storage/test_vocab.py .....................................       [100%]

----------- coverage: platform linux, python 3.6.7-final-0 -----------
Name                                                     Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------
takepod/__init__.py                                         14      0   100%
takepod/dataload/__init__.py                                 0      0   100%
takepod/dataload/cornell_movie_dialogs.py                   58      2    97%   13-14
takepod/dataload/eurovoc.py                                198    142    28%   115, 134-157, 183-251, 270-319, 336-348, 362-374, 389-418, 437-458, 473-509, 527
takepod/dataload/ner_croatian.py                            62      0   100%
takepod/datasets/__init__.py                                10      0   100%
takepod/datasets/dataset.py                                161      3    98%   430-433
takepod/datasets/hierarhical_dataset.py                    121      4    97%   215, 310-313
takepod/datasets/impl/__init__.py                            6      0   100%
takepod/datasets/impl/catacx_comments_dataset.py            40      4    90%   53-66
takepod/datasets/impl/catacx_dataset.py                     57      3    95%   28-29, 48
takepod/datasets/impl/cornell_movie_dialogs_dataset.py      40      0   100%
takepod/datasets/impl/croatian_ner_dataset.py               39      0   100%
takepod/datasets/impl/eurovoc_dataset.py                    93      0   100%
takepod/datasets/impl/imdb_sentiment_dataset.py             52      0   100%
takepod/datasets/impl/pauza_dataset.py                      40      0   100%
takepod/datasets/iris_dataset.py                            20      1    95%   35
takepod/datasets/iterator.py                               196     15    92%   100, 386, 577-581, 584-587, 625, 674, 682, 703-707, 710
takepod/datasets/tabular_dataset.py                         40      0   100%
takepod/examples/__init__.py                                 0      0   100%
takepod/examples/dataset_example.py                         14     14     0%   2-28
takepod/examples/experiment_example.py                      58     58     0%   2-127
takepod/examples/keywords_example.py                        19     19     0%   2-74
takepod/examples/model_example.py                           35     15    57%   47-73, 78
takepod/examples/ner_example.py                             93     93     0%   3-196
takepod/examples/tfidf_svm_example.py                       37     37     0%   2-58
takepod/examples/vectors_example.py                         15     15     0%   3-25
takepod/metrics/__init__.py                                  2      0   100%
takepod/metrics/metrics.py                                  10      3    70%   8-9, 21
takepod/model_selection/__init__.py                          2      2     0%   2-4
takepod/model_selection/grid_search.py                      39     39     0%   1-118
takepod/models/__init__.py                                   6      0   100%
takepod/models/batch_transform_functions.py                 14      0   100%
takepod/models/experiment.py                                75     10    87%   169-172, 175, 226-229, 282-285
takepod/models/impl/__init__.py                              4      0   100%
takepod/models/impl/blcc/__init__.py                         0      0   100%
takepod/models/impl/blcc/chain_crf.py                      176    176     0%   5-416
takepod/models/impl/blcc_model.py                          100    100     0%   2-228
takepod/models/impl/eurovoc_models/__init__.py               2      0   100%
takepod/models/impl/eurovoc_models/multilabel_svm.py       112     54    52%   190, 253-322
takepod/models/impl/fc_model.py                             18      2    89%   9-10
takepod/models/impl/simple_trainers.py                      13      0   100%
takepod/models/impl/svm_model.py                            20      3    85%   9-10, 34
takepod/models/model.py                                     14      5    64%   36, 55, 67, 90, 116
takepod/models/trainer.py                                    9      1    89%   40
takepod/models/transformers.py                              40      4    90%   27, 44, 54, 86
takepod/pipeline/__init__.py                                 2      0   100%
takepod/pipeline/pipeline.py                                26      6    77%   69-73, 75-79
takepod/preproc/__init__.py                                  4      0   100%
takepod/preproc/lemmatizer/__init__.py                       2      0   100%
takepod/preproc/lemmatizer/croatian_lemmatizer.py           63      0   100%
takepod/preproc/stemmer/__init__.py                          2      0   100%
takepod/preproc/stemmer/croatian_stemmer.py                 46      0   100%
takepod/preproc/stop_words.py                               13      0   100%
takepod/preproc/tokenizers.py                               21      0   100%
takepod/preproc/util.py                                     35      0   100%
takepod/preproc/yake.py                                     14      4    71%   45, 56, 70-71
takepod/storage/__init__.py                                  8      0   100%
takepod/storage/example_factory.py                          85     18    79%   42-45, 161-167, 225-226, 252-262, 283
takepod/storage/field.py                                   222      6    97%   153, 174, 587-589, 719
takepod/storage/resources/__init__.py                        0      0   100%
takepod/storage/resources/downloader.py                     54     15    72%   45, 113-132, 160
takepod/storage/resources/large_resource.py                 70      2    97%   110, 144
takepod/storage/resources/utility.py                        28      9    68%   53-55, 77-82
takepod/storage/vectorizers/__init__.py                      0      0   100%
takepod/storage/vectorizers/impl/__init__.py                 3      0   100%
takepod/storage/vectorizers/impl/glove.py                   26      6    77%   98-110
takepod/storage/vectorizers/impl/nlpl.py                    12      3    75%   17-27
takepod/storage/vectorizers/tfidf.py                        99      9    91%   197-201, 262-265, 267-269
takepod/storage/vectorizers/vectorizer.py                  134     13    90%   84, 107, 133, 152, 163, 182, 315-318, 330-334
takepod/storage/vocab.py                                   122      7    94%   248-251, 334, 338, 340, 342, 361
takepod/validation/__init__.py                               3      0   100%
takepod/validation/kfold.py                                  7      3    57%   26-28
takepod/validation/validation.py                            36     25    31%   55-71, 114-121, 206-237
--------------------------------------------------------------------------------------
TOTAL                                                     3311    950    71%
```