### PR TITLE
Per-field custom datatype support

### DIFF
--- a/takepod/storage/field.py
+++ b/takepod/storage/field.py
@@ -189,6 +189,7 @@ class Field:
                  store_as_raw=True,
                  store_as_tokenized=False,
                  eager=True,
+                 is_numericalizable=True,
                  custom_numericalize=None,
                  is_target=False,
                  fixed_length=None,
@@ -238,6 +239,20 @@ class Field:
         eager : bool
             Whether to build the vocabulary online, each time the field
             preprocesses raw data.
+        is_numericalizable : bool
+            Whether the output of tokenizer can be numericalized.
+
+            If true, the output of the tokenizer is presumed to be a list of tokens and
+            will be numericalized using the provided Vocab or custom_numericalize.
+            For numericalizable fields, Iterator will generate batch fields containing
+             numpy matrices.
+
+             If false, the out of the tokenizer is presumed to be a custom datatype.
+             Posttokenization hooks aren't allowed to be added as they can't be called
+             on custom datatypes. For non-numericalizable fields, Iterator will generate
+             batch fields containing lists of these custom data type instances returned
+             by the tokenizer.
+
         custom_numericalize : callable
             The numericalization function that will be called if the field
             doesn't use a vocabulary.
@@ -268,6 +283,7 @@ class Field:
         self.name = name
         self.language = language
         self._tokenizer_arg = tokenizer
+        self.is_numericalizable = is_numericalizable
 
         if store_as_tokenized and tokenize:
             error_msg = "Store_as_tokenized' and 'tokenize' both set to True." \
@@ -290,7 +306,15 @@ class Field:
             _LOGGER.error(error_msg)
             raise ValueError(error_msg)
 
-        self.sequential = store_as_tokenized or tokenize
+        if not is_numericalizable \
+                and (custom_numericalize is not None or vocab is not None):
+            error_msg = "Field that is not numericalizable can't have " \
+                        "custom_numericalize or vocab."
+
+            _LOGGER.error(error_msg)
+            raise ValueError(error_msg)
+
+        self.is_sequential = (store_as_tokenized or tokenize) and is_numericalizable
         self.store_as_raw = store_as_raw
         self.tokenize = tokenize
         self.store_as_tokenized = store_as_tokenized
@@ -373,6 +397,11 @@ class Field:
         hook : callable
             The post-tokenization hook that we want to add to the field.
         """
+        if not self.is_numericalizable:
+            error_msg = "Field is declared as non numericalizable. Posttokenization " \
+                        "hooks aren't used in such fields."
+            _LOGGER.error(error_msg)
+            raise ValueError(error_msg)
 
         self.posttokenize_pipeline.add_hook(hook)
 
@@ -517,7 +546,8 @@ class Field:
             the data and tokens processed by posttokenization hooks.
         """
 
-        data, tokens = self._run_posttokenization_hooks(data, tokens)
+        if self.is_numericalizable:
+            data, tokens = self._run_posttokenization_hooks(data, tokens)
 
         if self.eager and self.use_vocab and not self.vocab.finalized:
             self.update_vocab(data, tokens)
@@ -558,7 +588,7 @@ class Field:
                 empty numpy array if the field is sequential or numpy array with one
                 None value otherwise.
         """
-        if self.sequential:
+        if self.is_sequential:
             return np.empty(0)
 
         return np.array([np.nan])
@@ -595,7 +625,11 @@ class Field:
         # raw data is just a string, so we need to wrap it into an iterable
         tokens = tokenized if self.tokenize or self.store_as_tokenized else [raw]
 
-        return self._numericalize_tokens(tokens)
+        if self.is_numericalizable:
+            return self._numericalize_tokens(tokens)
+
+        else:
+            return tokens
 
     def pad_to_length(self, row, length, custom_pad_symbol=None,
                       pad_left=False, truncate_left=False):
@@ -717,8 +751,8 @@ class Field:
         self.tokenizer = get_tokenizer(self._tokenizer_arg, self.language)
 
     def __str__(self):
-        return "{}[name: {}, sequential: {}, is_target: {}]".format(
-            self.__class__.__name__, self.name, self.sequential, self.is_target)
+        return "{}[name: {}, is_sequential: {}, is_target: {}]".format(
+            self.__class__.__name__, self.name, self.is_sequential, self.is_target)
 
     def get_output_fields(self):
         """Returns an Iterable of the contained output fields.
@@ -839,8 +873,8 @@ class MultilabelField(TokenizedField):
 
         if self.use_vocab and len(self.vocab) > self.num_of_classes:
             error_msg = "Number of classes in data is greater than the declared number " \
-                        "of classes. Declared: {}, Actual: {}".format(
-                            self.num_of_classes, len(self.vocab))
+                        "of classes. Declared: {}, Actual: {}"\
+                .format(self.num_of_classes, len(self.vocab))
             _LOGGER.error(error_msg)
             raise ValueError(error_msg)
 

--- a/test/storage/test_field.py
+++ b/test/storage/test_field.py
@@ -73,7 +73,7 @@ def test_field_preprocess_eager():
 
 
 @pytest.mark.parametrize(
-    "value, store_raw, sequential, expected_raw_value, "
+    "value, store_raw, is_sequential, expected_raw_value, "
     "expected_tokenized_value",
     [
         ("some text", True, True, "some text", ["some", "text"]),
@@ -81,10 +81,10 @@ def test_field_preprocess_eager():
         ("some text", False, True, None, ["some", "text"]),
     ]
 )
-def test_field_preprocess_raw_sequential(value, store_raw, sequential,
+def test_field_preprocess_raw_sequential(value, store_raw, is_sequential,
                                          expected_raw_value,
                                          expected_tokenized_value):
-    f = Field(name="F", store_as_raw=store_raw, tokenize=sequential)
+    f = Field(name="F", store_as_raw=store_raw, tokenize=is_sequential)
 
     (_, (received_raw_value, received_tokenized_value)), = f.preprocess(value)
 
@@ -93,7 +93,7 @@ def test_field_preprocess_raw_sequential(value, store_raw, sequential,
 
 
 @pytest.mark.parametrize(
-    "value, store_raw, sequential, expected_raw_value, "
+    "value, store_raw, is_sequential, expected_raw_value, "
     "expected_tokenized_value",
     [
         ("some text", True, True, "some text", ["some", "text"]),
@@ -101,10 +101,10 @@ def test_field_preprocess_raw_sequential(value, store_raw, sequential,
         ("some text", False, True, None, ["some", "text"]),
     ]
 )
-def test_field_pickle_tokenized(value, store_raw, sequential,
+def test_field_pickle_tokenized(value, store_raw, is_sequential,
                                 expected_raw_value,
                                 expected_tokenized_value, tmpdir):
-    fld = Field(name="F", store_as_raw=store_raw, tokenize=sequential)
+    fld = Field(name="F", store_as_raw=store_raw, tokenize=is_sequential)
 
     (_, (received_raw_value, received_tokenized_value)), = fld.preprocess(value)
 
@@ -124,7 +124,7 @@ def test_field_pickle_tokenized(value, store_raw, sequential,
         assert tokenized_value == expected_tokenized_value
         assert loaded_fld.name == "F"
         assert loaded_fld.store_as_raw == store_raw
-        assert loaded_fld.sequential == sequential
+        assert loaded_fld.is_sequential == is_sequential
 
 
 @pytest.mark.parametrize(
@@ -141,7 +141,7 @@ def test_field_use_vocab(vocab, expected_value):
 
 
 @pytest.mark.parametrize(
-    "use_vocab, sequential, expected_vocab_values",
+    "use_vocab, is_sequential, expected_vocab_values",
     [
         (False, False, []),
         (False, True, []),
@@ -149,10 +149,10 @@ def test_field_use_vocab(vocab, expected_value):
         (True, True, ["some", "text"]),
     ]
 )
-def test_field_update_vocab(use_vocab, sequential, expected_vocab_values):
+def test_field_update_vocab(use_vocab, is_sequential, expected_vocab_values):
     vocab = MockVocab()
     f = Field(name="F", vocab=vocab if use_vocab else None,
-              tokenize=sequential)
+              tokenize=is_sequential)
 
     raw_value = "some text"
     tokenized_value = ["some", "text"]

--- a/test/storage/test_iterator.py
+++ b/test/storage/test_iterator.py
@@ -1,5 +1,4 @@
 import random
-import copy
 
 from test.storage.conftest import (
     create_tabular_dataset_from_json, tabular_dataset_fields, TABULAR_TEXT)
@@ -113,6 +112,34 @@ def test_create_batch(tabular_dataset):
         else:
             assert x_batch.text.shape[0] == batch_size
             assert y_batch.rating.shape[0] == batch_size
+
+
+@pytest.mark.usefixtures("json_file_path")
+def test_not_numericalizable_field(json_file_path):
+    class MockCustomDataClass:
+
+        def __init__(self, data):
+            self.data = data
+
+    def custom_datatype_tokenizer(data):
+        return MockCustomDataClass(data)
+
+    fields = tabular_dataset_fields()
+    text_field = fields['text']
+    non_numericalizable_field = Field("non_numericalizable_field",
+                                      tokenizer=custom_datatype_tokenizer,
+                                      is_numericalizable=False)
+
+    fields['text'] = (text_field, non_numericalizable_field)
+
+    dataset = create_tabular_dataset_from_json(fields, json_file_path)
+    dataset.finalize_fields()
+
+    for x_batch, _ in Iterator(dataset, batch_size=len(dataset)):
+        assert isinstance(x_batch.non_numericalizable_field, (list, tuple))
+        for batch_data, real_data in zip(x_batch.non_numericalizable_field, TABULAR_TEXT):
+            assert isinstance(batch_data, MockCustomDataClass)
+            assert batch_data.data == real_data
 
 
 @pytest.mark.usefixtures("tabular_dataset")
@@ -337,44 +364,6 @@ def np_arrays_equal(arr_1, arr_2):
         arrs_equal = arrs_equal.all()
 
     return arrs_equal
-
-
-@pytest.mark.usefixtures("tabular_dataset")
-def test_batch_as_vector_list(tabular_dataset):
-    tabular_dataset.finalize_fields()
-    text_vocab = tabular_dataset.field_dict["text"].vocab
-
-    # case where we have both input and target fields
-    iterator = Iterator(tabular_dataset, batch_size=3, batch_to_matrix=False)
-
-    example_index = 0
-    for x_batch, y_batch in iterator:
-        assert isinstance(x_batch.text, list)
-        assert isinstance(y_batch.rating, list)
-
-        for x, y in zip(x_batch.text, y_batch.rating):
-            example = tabular_dataset[example_index]
-            assert all(x == text_vocab.numericalize(example.text[1]))
-            assert y == [example.rating[0]]
-            example_index += 1
-
-    # case where we have only input fields
-    tabular_dataset = copy.deepcopy(tabular_dataset)
-    tabular_dataset.field_dict["rating"].is_target = False
-
-    iterator = Iterator(tabular_dataset, batch_size=3, batch_to_matrix=False)
-
-    example_index = 0
-    for x_batch, y_batch in iterator:
-        assert isinstance(x_batch.text, list)
-        assert isinstance(x_batch.rating, list)
-        assert not y_batch
-
-        for example_text, example_rating in zip(x_batch.text, x_batch.rating):
-            example = tabular_dataset[example_index]
-            assert all(example_text == text_vocab.numericalize(example.text[1]))
-            assert example_rating == [example.rating[0]]
-            example_index += 1
 
 
 @pytest.fixture()


### PR DESCRIPTION
Added the option to declare a `Field` being non-numericalizable through the new parameter `is_numericalizable`.

Non-numericlizable fields have tokenizers which are presumed to return a custom data type. Usage example of this would be storing parsed dependency trees.

Iterators treat non-numericalized fields in a special way. For these fields, the batch entry is not a matrx, but a list of these custom objects which can be used in feature extraction.