### PR TITLE
Add logic to determine feature fields for Multioutput Fields and Field tuples

### DIFF
--- a/takepod/pipeline/pipeline.py
+++ b/takepod/pipeline/pipeline.py
@@ -2,7 +2,7 @@ from typing import Union, Dict, List, Callable, NamedTuple, Any, Type, Iterable
 import logging
 
 from takepod.storage import ExampleFactory, ExampleFormat
-from takepod.storage.field import Field, LabelField, MultioutputField
+from takepod.storage.field import Field, MultioutputField
 from takepod.datasets import Dataset
 from takepod.models import AbstractSupervisedModel, FeatureTransformer, Experiment, \
     AbstractTrainer
@@ -259,8 +259,7 @@ def _filter_feature_fields(fields):
         elif isinstance(field, tuple) and not all(map(is_target, field)):
             feature_fields[field_key] = field
         # all instances of Fields, except LabelField are feature fields
-        elif isinstance(field, Field) and \
-                not isinstance(field, LabelField) and not field.is_target:
+        elif isinstance(field, Field) and not field.is_target:
             feature_fields[field_key] = field
 
     return feature_fields


### PR DESCRIPTION
Having targets in Multioutput and tuple fields breaks current pipeline behavior, since pipelines split fields between target (feature_field) and non-target. 

This PR includes logic of determining whether a MultioutputField and tuple of Fields are considered feature fields or not. The logic is that if there exists at least one non-target Field in either a MultioutputField (and tuple of Fields) it is considered a feature field. 

An example of using a MultioutputField with targets and non-targets is language modeling where one field might be masked text and the other unmasked text (which you are trying to predict). 

If new types of nested Fields arise, they might need to have some logic to determine whether they contain a target Field or not.  