### PR TITLE
Hierarchical dataset pre- post-context generation

### DIFF
--- a/takepod/datasets/dataset.py
+++ b/takepod/datasets/dataset.py
@@ -222,7 +222,7 @@ class Dataset(ABC):
 
         Parameters
         ----------
-        \*args
+        *args
             A variable number of Dataset objects from which to build the
             vocabularies for non-eager fields. If none provided, the
             vocabularies are built from this Dataset (self).

--- a/takepod/datasets/hierarhical_dataset.py
+++ b/takepod/datasets/hierarhical_dataset.py
@@ -339,8 +339,8 @@ class HierarchicalDataset:
 
         # Go up the hierarchy `level` times
         parent = node
-        while parent.parent is not None and levels >= 0:
-            parent = parent.parent
+        while parent.parent_node is not None and levels >= 0:
+            parent = parent.parent_node
             levels -= 1
 
         def pre_context_node_iterator(start_node, finish_node):

--- a/takepod/datasets/hierarhical_dataset.py
+++ b/takepod/datasets/hierarhical_dataset.py
@@ -468,8 +468,8 @@ class HierarchicalDataset:
             Returns
             -------
             Iterator(Example)
-                an Iterator iterating through the pre-context of the Example with the passed
-                index.
+                an Iterator iterating through the pre-context of the Example with the
+                passed index.
         """
         node = self._get_node_by_index(index)
         post_context_nodes = HierarchicalDataset._get_post_context_nodes(

--- a/takepod/datasets/iterator.py
+++ b/takepod/datasets/iterator.py
@@ -609,10 +609,10 @@ class HierarchicalDatasetIterator(Iterator):
             limitations.
 
         """
-        context_iterator = HierarchicalDataset._get_node_context(
+        context_iterator = HierarchicalDataset._get_pre_context_nodes(
             node, self._context_max_depth
         )
-        context = list(context_iterator)
+        context = list(n.example for n in context_iterator)
 
         if self._context_max_size is not None:
             # if context max size is defined, truncate it

--- a/test/datasets/test_catacx_dataset.py
+++ b/test/datasets/test_catacx_dataset.py
@@ -30,14 +30,14 @@ def validate_example_catacx_dataset(dataset):
     assert root_example_1.spam[0] is False
     assert root_example_1.emotions[1] == ["interest"]
 
-    comment_1 = root_nodes[0].children[0].example
+    comment_1 = root_nodes[0].children_nodes[0].example
 
     assert comment_1.likes_cnt[0] == 0
     assert comment_1.message[1] == ["Comment", "No.1", "text"]
     assert comment_1.cs[1] == ["answer"]
     assert comment_1.irony == (None, None)
 
-    reply_1 = root_nodes[0].children[0].children[0].example
+    reply_1 = root_nodes[0].children_nodes[0].children_nodes[0].example
 
     assert reply_1.speech_acts[1] == ["praising", "stating"]
     assert reply_1.irony[0] is False

--- a/test/storage/test_dataset.py
+++ b/test/storage/test_dataset.py
@@ -804,7 +804,7 @@ def hierarchical_dataset(hierarchical_dataset_fields, hierarchical_dataset_parse
                                          parser=hierarchical_dataset_parser)
 
 
-def test_create_hierarchical_dataset_from_json(hierarchical_dataset):
+def test_hierarchical_dataset_loaded(hierarchical_dataset):
     root_nodes = hierarchical_dataset._root_nodes
 
     assert root_nodes[0].example.name[0] == "parent1"
@@ -933,7 +933,7 @@ def test_hierarchical_dataset_pickle(tmpdir, hierarchical_dataset):
 
     with open(dataset_file, "rb") as fdata:
         loaded_dataset = dill.load(fdata)
-        test_create_hierarchical_dataset_from_json(loaded_dataset)
+        test_hierarchical_dataset_loaded(loaded_dataset)
 
 
 HIERARCHIAL_DATASET_JSON_EXAMPLE = """

--- a/test/storage/test_dataset.py
+++ b/test/storage/test_dataset.py
@@ -825,7 +825,7 @@ def test_create_hierarchical_dataset_from_json(hierarchical_dataset):
     assert root_nodes[1].children_nodes[0].example.name[0] == "c21"
     assert root_nodes[1].children_nodes[0].example.number[0] == 6
 
-    assert len(hierarchical_dataset) == 10
+    assert len(hierarchical_dataset) == 11
     assert hierarchical_dataset.depth == 2
 
 
@@ -835,20 +835,14 @@ def test_flatten_hierarchical_dataset(hierarchical_dataset):
         assert example.number[0] == index + 1
         count += 1
 
-    assert count == 10
+    assert count == 11
 
 
 def test_hierarchical_dataset_example_indexing(hierarchical_dataset):
-    assert hierarchical_dataset[0].name[0] == "parent1"
-    assert hierarchical_dataset[1].name[0] == "c11"
-    assert hierarchical_dataset[2].name[0] == "c111"
-    assert hierarchical_dataset[3].name[0] == "c12"
-    assert hierarchical_dataset[4].name[0] == "parent2"
-    assert hierarchical_dataset[5].name[0] == "c21"
-    assert hierarchical_dataset[6].name[0] == "c22"
-    assert hierarchical_dataset[7].name[0] == "c23"
-    assert hierarchical_dataset[8].name[0] == "c231"
-    assert hierarchical_dataset[9].name[0] == "c24"
+    expected_names = ["parent1", "c11", "c111", "c12", "parent2",
+                      "c21", "c22", "c23", "c231", "c232", "c24"]
+    for i, expected in enumerate(expected_names):
+        assert hierarchical_dataset[i].name[0] == expected
 
 
 def test_hierarchical_dataset_finalize_fields(hierarchical_dataset_parser):


### PR DESCRIPTION
Adds methods that can extract pre- and post-context examples from hierarchical datasets.
Also fixes a bug in `HierarchicalDataset`'s `finalize_fields` method.

This was made as a request from another project. Not required for some time in the future so reviewing this is not a priority.