### PR TITLE
Fixing tests to avoid make requests calls

### DIFF
--- a/test/datasets/test_sst_dataset.py
+++ b/test/datasets/test_sst_dataset.py
@@ -37,7 +37,7 @@ def mock_dataset_path():
     base_temp = tempfile.mkdtemp()
     assert os.path.exists(base_temp)
     LargeResource.BASE_RESOURCE_DIR = base_temp
-    base_dataset_dir = os.path.join(base_temp, "trees")
+    base_dataset_dir = os.path.join(base_temp, "sst", "trees")
     os.makedirs(base_dataset_dir)
     train_filename = os.path.join(base_dataset_dir, 'train.txt')
     create_examples(train_filename, RAW_EXAMPLES)


### PR DESCRIPTION
Avoid making requests and simply use local files. 

Tested by supplying invalid URL for SST dataset location and it worked only with this change. 

Solves part of issue: https://github.com/mttk/podium/issues/188