### PR TITLE
Added 1.0.0 minimal version req for pyarrow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ QUALITY_REQUIRE = [
 DATASETS_REQUIRE = [
     'conllu',
     'datasets',
-    'pyarrow',
+    'pyarrow>=1.0.0',
     'xlrd',
 ]
 


### PR DESCRIPTION
Updates `setup.py` to add the minimal version of `pyarrow` we support. Versions under 1.0.0. are missing the `take` function in `pyarrow.Table`.