### PR TITLE
[WIP] Add more standard repr

### DIFF
--- a/podium/datasets/dataset.py
+++ b/podium/datasets/dataset.py
@@ -8,8 +8,10 @@ from typing import Callable, Iterable, List, Union
 
 from podium.datasets.dataset_abc import DatasetABC
 from podium.storage.example_factory import Example
+from podium.utils import add_repr
 
 
+@add_repr(inspect_init=True)
 class Dataset(DatasetABC):
     """
     A general purpose container for datasets. A dataset is a shallow wrapper for

--- a/podium/datasets/dataset_abc.py
+++ b/podium/datasets/dataset_abc.py
@@ -16,11 +16,13 @@ from typing import (
 import numpy as np
 
 from podium.storage import Example, Field, unpack_fields
+from podium.utils import add_repr
 
 
 FieldType = Optional[Union[Field, List[Field]]]
 
 
+@add_repr(inspect_init=True)
 class DatasetABC(ABC):
     def __init__(self, fields: Union[Dict[str, FieldType], List[FieldType]]):
         self._fields = tuple(unpack_fields(fields))
@@ -207,9 +209,6 @@ class DatasetABC(ABC):
         """
         shuffled_indices = np.random.permutation(len(self))
         return self[shuffled_indices]
-
-    def __repr__(self):
-        return f"{type(self).__name__}[Size: {len(self)}, Fields: {self.fields}]"
 
     # ================= Abstract methods =======================
 

--- a/podium/datasets/iterator.py
+++ b/podium/datasets/iterator.py
@@ -13,6 +13,7 @@ import numpy as np
 
 from podium.datasets.dataset import Dataset, DatasetABC
 from podium.datasets.hierarhical_dataset import HierarchicalDataset
+from podium.utils import add_repr
 
 
 class IteratorABC(ABC):
@@ -84,6 +85,7 @@ class IteratorABC(ABC):
     pass
 
 
+@add_repr(inspect_init=True, exclude_attrs=["seed", "internal_random_state"])
 class Iterator(IteratorABC):
     """
     An iterator that batches data from a dataset after numericalization.
@@ -401,14 +403,6 @@ class Iterator(IteratorABC):
 
         return max(map(numericalization_length, numericalizations))
 
-    def __repr__(self) -> str:
-        return "{}[batch_size: {}, sort_key: {}, shuffle: {}]".format(
-            self.__class__.__name__,
-            self._batch_size,
-            self._sort_key,
-            self._shuffle,
-        )
-
 
 class SingleBatchIterator(Iterator):
     """
@@ -445,6 +439,7 @@ class SingleBatchIterator(Iterator):
         return 1
 
 
+@add_repr(inspect_init=True, exclude_attrs=["seed"])
 class BucketIterator(Iterator):
     """
     Creates a bucket iterator that uses a look-ahead heuristic to try and batch
@@ -528,20 +523,8 @@ class BucketIterator(Iterator):
         self._iterations = 0
         self._epoch += 1
 
-    def __repr__(self) -> str:
-        return (
-            "{}[batch_size: {}, sort_key: {}, "
-            "shuffle: {}, look_ahead_multiplier: {}, bucket_sort_key: {}]".format(
-                self.__class__.__name__,
-                self._batch_size,
-                self._sort_key,
-                self._shuffle,
-                self.look_ahead_multiplier,
-                self.bucket_sort_key,
-            )
-        )
 
-
+@add_repr(inspect_init=True, exclude_attrs=["seed", "internal_random_state"])
 class HierarchicalDatasetIterator(Iterator):
     """
     Iterator used to create batches for Hierarchical Datasets.
@@ -637,11 +620,11 @@ class HierarchicalDatasetIterator(Iterator):
         if context_max_depth is not None and context_max_depth < 0:
             raise ValueError(
                 "'context_max_depth' must not be negative. "
-                f"'context_max_depth' : {context_max_length}"
+                f"'context_max_depth' : {context_max_depth}"
             )
 
         self._context_max_depth = context_max_depth
-        self._context_max_size = context_max_length
+        self._context_max_length = context_max_length
 
         super().__init__(
             dataset,
@@ -685,9 +668,9 @@ class HierarchicalDatasetIterator(Iterator):
         )
         context = list(context_iterator)
 
-        if self._context_max_size is not None:
+        if self._context_max_length is not None:
             # if context max size is defined, truncate it
-            context = context[-self._context_max_size :]
+            context = context[-self._context_max_length :]
 
         # add the example to the end of its own context
         context.append(node.example)
@@ -766,16 +749,3 @@ class HierarchicalDatasetIterator(Iterator):
         # prepare for new epoch
         self._iterations = 0
         self._epoch += 1
-
-    def __repr__(self) -> str:
-        return (
-            "{}[batch_size: {}, sort_key: {}, "
-            "shuffle: {}, context_max_length: {}, context_max_depth: {}]".format(
-                self.__class__.__name__,
-                self._batch_size,
-                self._sort_key,
-                self._shuffle,
-                self._context_max_size,
-                self._context_max_depth,
-            )
-        )

--- a/podium/models/experiment.py
+++ b/podium/models/experiment.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from podium.datasets.dataset import Dataset
 from podium.datasets.iterator import Iterator, SingleBatchIterator
+from podium.utils import add_repr
 
 from .batch_transform_functions import default_feature_transform, default_label_transform
 from .model import AbstractSupervisedModel
@@ -14,6 +15,7 @@ from .trainer import AbstractTrainer
 from .transformers import FeatureTransformer
 
 
+@add_repr(include_attrs=["model", "trainer"])
 class Experiment:
     """
     Class used to streamline model fitting and prediction.
@@ -310,6 +312,3 @@ class Experiment:
                 "a model instance in the constructor or call `fit` "
                 "before calling `partial_fit.`"
             )
-
-    def __repr__(self):
-        return f"{type(self).__name__}[model: {self.model}, trainer: {self.trainer}]"

--- a/podium/storage/example_factory.py
+++ b/podium/storage/example_factory.py
@@ -9,6 +9,8 @@ import xml.etree.ElementTree as ET
 from enum import Enum
 from typing import Union
 
+from podium.utils import add_repr
+
 
 class ExampleFormat(Enum):
     LIST = "list"
@@ -67,6 +69,7 @@ class Example(dict):
         return ExampleFactory(fields)
 
 
+@add_repr(inspect_init=True)
 class ExampleFactory:
     """
     Class used to create Example instances.

--- a/podium/storage/vocab.py
+++ b/podium/storage/vocab.py
@@ -9,6 +9,8 @@ from typing import Iterable, Union
 
 import numpy as np
 
+from podium.utils import add_repr
+
 
 def unique(values: Iterable):
     """
@@ -66,6 +68,7 @@ class SpecialVocabSymbols(Enum):
     PAD = "<pad>"
 
 
+@add_repr(inspect_init=True, include_attrs=["finalized"])
 class Vocab:
     """
     Class for storing vocabulary. It supports frequency counting and size
@@ -513,9 +516,6 @@ class Vocab:
         if not self.finalized:
             return iter(self._freqs.keys())
         return iter(self.itos)
-
-    def __repr__(self):
-        return f"{type(self).__name__}[finalized: {self.finalized}, size: {len(self)}]"
 
     def __getitem__(self, token):
         """

--- a/podium/utils/__init__.py
+++ b/podium/utils/__init__.py
@@ -1,0 +1,1 @@
+from .general_utils import add_repr

--- a/podium/utils/general_utils.py
+++ b/podium/utils/general_utils.py
@@ -1,0 +1,53 @@
+"""
+General utilities used across the codebase.
+"""
+
+import inspect
+
+
+def add_repr(*, inspect_init=False, include_attrs=None, exclude_attrs=None):
+    def repr_decorator(cls):
+        def attrs_type(x):
+            x = x or []
+            if isinstance(x, str):
+                x = [x]
+            return x
+
+        nonlocal include_attrs
+        nonlocal exclude_attrs
+
+        include_attrs = attrs_type(include_attrs)
+        exclude_attrs = attrs_type(exclude_attrs)
+
+        if inspect_init:
+            attrs = list(inspect.signature(cls.__init__).parameters)[1:]
+            if include_attrs:
+                extra_attrs = [attr for attr in include_attrs if attr not in attrs]
+                attrs = attrs + extra_attrs
+        else:
+            attrs = include_attrs
+
+        attrs = [attr for attr in attrs if attr not in exclude_attrs]
+
+        def _repr(self):
+            attrs_dict = {}
+            for attr in attrs:
+                attr_name = attr
+                if not hasattr(self, attr):
+                    if attr.startswith("_"):
+                        attr = attr.lstrip("_")
+                    else:
+                        attr = "_" + attr
+                attrs_dict[attr_name] = getattr(self, attr)
+
+            return (
+                self.__class__.__qualname__
+                + "("
+                + ", ".join(f"{attr}={val!r}" for attr, val in attrs_dict.items())
+                + ")"
+            )
+
+        cls.__repr__ = _repr
+        return cls
+
+    return repr_decorator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,0 @@
-import logging
-
-import podium
-
-
-LOGGER = logging.getLogger(podium.__name__)
-LOGGER.setLevel(logging.CRITICAL)


### PR DESCRIPTION
This PR adds the `add_repr` decorator to standardize reprs in Podium.  `add_repr` acts as a convenience decorator, but if this approach seems too error-prone, we can do this by hand as @ivansmokovic suggests. 


add_repr accepts 3 arguments:
infer_init: if True, infers attributes from the class `__init__`
include_attrs: a list of attributes to add to the `__repr__` 
exclude_attrs: a list of attributes to exclude from the `__repr__` 

Right now, we don't test the reprs, so I'll edit this comment to show you how the actual reprs produced with `add_repr` look like.

