### PR TITLE
fixed test for windows

### DIFF
--- a/tests/datasets/test_pyarrow_tabular_dataset.py
+++ b/tests/datasets/test_pyarrow_tabular_dataset.py
@@ -1,6 +1,5 @@
 import csv
 import os
-import sys
 import tempfile
 from functools import partial
 
@@ -217,13 +216,9 @@ def test_from_dataset(data, fields):
     pyarrow_dataset.delete_cache()
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="the reason for failure on Windows is not known at the moment",
-)
 def test_from_tabular(data, fields, tmpdir):
     test_file = os.path.join(tmpdir, "test.csv")
-    with open(test_file, "w") as f:
+    with open(test_file, "w", newline="") as f:
         writer = csv.writer(f)
         writer.writerows(data)
 


### PR DESCRIPTION
Resolves #201.
Fixed the failing test on Windows.

The cause was python's CSV writer. For some reason, when writing CSV files, every second row is empty.
This is caused by the CSV writer writing out `\r\n` and Windows adding a `\r` at runtime, so the actual line written to the file would end with `\r\r\n`.

This was simply fixed by adding `newline=''` to the `open` command where the file is being written. This could be a reoccurring problem in the future.

Some references for this bizarre behavior:

- https://stackoverflow.com/questions/3191528/csv-in-python-adding-an-extra-carriage-return-on-windows
- https://bugs.python.org/issue7198

Basically, on Windows, you have to open csv files in binary mode to be safe.