### PR TITLE
Add support for pickle to HFDatasetConverter and DiskBackedDataset

### DIFF
--- a/podium/datasets/arrow.py
+++ b/podium/datasets/arrow.py
@@ -176,14 +176,10 @@ class DiskBackedDataset(DatasetBase):
         fields = unpack_fields(fields)
 
         if cache_path is None:
-            cache_path = tempfile.mkdtemp(
-                prefix=TEMP_CACHE_FILENAME_PREFIX
-            )
+            cache_path = tempfile.mkdtemp(prefix=TEMP_CACHE_FILENAME_PREFIX)
 
         # dump dataset table
-        cache_table_path = os.path.join(
-            cache_path, CACHE_TABLE_FILENAME
-        )
+        cache_table_path = os.path.join(cache_path, CACHE_TABLE_FILENAME)
 
         # TODO hande cache case when cache is present
 
@@ -545,9 +541,7 @@ class DiskBackedDataset(DatasetBase):
             the DiskBackedDataset loaded from the passed cache directory.
         """
         # load fields
-        fields_file_path = os.path.join(
-            cache_path, CACHE_FIELDS_FILENAME
-        )
+        fields_file_path = os.path.join(cache_path, CACHE_FIELDS_FILENAME)
         with open(fields_file_path, "rb") as fields_cache_file:
             fields = pickle.load(fields_cache_file)
 
@@ -586,24 +580,18 @@ class DiskBackedDataset(DatasetBase):
             )
 
         if cache_path is None:
-            cache_path = tempfile.mkdtemp(
-                prefix=TEMP_CACHE_FILENAME_PREFIX
-            )
+            cache_path = tempfile.mkdtemp(prefix=TEMP_CACHE_FILENAME_PREFIX)
 
         if not os.path.isdir(cache_path):
             os.mkdir(cache_path)
 
         # pickle fields
-        cache_fields_path = os.path.join(
-            cache_path, CACHE_FIELDS_FILENAME
-        )
+        cache_fields_path = os.path.join(cache_path, CACHE_FIELDS_FILENAME)
         with open(cache_fields_path, "wb") as fields_cache_file:
             pickle.dump(self.fields, fields_cache_file)
 
         # dump table
-        cache_table_path = os.path.join(
-            cache_path, CACHE_TABLE_FILENAME
-        )
+        cache_table_path = os.path.join(cache_path, CACHE_TABLE_FILENAME)
         with pa.OSFile(cache_table_path, "wb") as f:
             with pa.RecordBatchFileWriter(f, self.table.schema) as writer:
                 writer.write(self.table)
@@ -854,6 +842,8 @@ class DiskBackedDataset(DatasetBase):
         return state
 
     def __setstate__(self, state):
-        mmapped_file = pa.memory_map(os.path.join(state["cache_path"], CACHE_TABLE_FILENAME))
+        mmapped_file = pa.memory_map(
+            os.path.join(state["cache_path"], CACHE_TABLE_FILENAME)
+        )
         state["mmapped_file"] = mmapped_file
         self.__dict__ = state

--- a/podium/datasets/dataset.py
+++ b/podium/datasets/dataset.py
@@ -346,7 +346,7 @@ class DatasetBase(ABC):
         return pd.DataFrame(data=row_iterator(), columns=column_names)
 
     def __getstate__(self):
-        return self.__dict__
+        return self.__dict__.copy()
 
     def __setstate__(self, state):
         self.__dict__ = state

--- a/podium/datasets/hierarhical_dataset.py
+++ b/podium/datasets/hierarhical_dataset.py
@@ -390,11 +390,9 @@ class HierarchicalDataset:
         state : dict
             dataset state dictionary
         """
-        d = dict(self.__dict__)
-
-        del d["_parser"]
-
-        return d
+        state = self.__dict__.copy()
+        del state["_parser"]
+        return state
 
     def __setstate__(self, state):
         """


### PR DESCRIPTION
`HFDatasetConverter` and `DiskBackedDataset` are the only core components that don't support the pickle protocol. This PR fixes this.