### PR TITLE
Replace csv.reader with pd.read_csv

### DIFF
--- a/podium/datasets/arrow.py
+++ b/podium/datasets/arrow.py
@@ -318,7 +318,11 @@ class DiskBackedDataset(DatasetBase):
 
             if format in {"csv", "tsv"}:
                 delimiter = "," if format == "csv" else "\t"
-                reader = iter(pd.read_csv(f, delimiter=delimiter, header=None, **csv_reader_params).values.tolist())
+                reader = iter(
+                    pd.read_csv(
+                        f, delimiter=delimiter, header=None, **csv_reader_params
+                    ).values.tolist()
+                )
             elif format == "json":
                 reader = f
             else:

--- a/podium/datasets/example_factory.py
+++ b/podium/datasets/example_factory.py
@@ -3,11 +3,13 @@ Module containing the Example Factory method used to dynamically create example
 classes used for storage in Dataset classes.
 """
 
-import csv
 import json
 import xml.etree.ElementTree as ET
 from enum import Enum
+from io import StringIO
 from typing import Union
+
+import pandas as pd
 
 from podium.utils.general_utils import repr_type_and_attrs
 
@@ -231,7 +233,8 @@ class ExampleFactory:
             An Example whose attributes are the given Fields created with the
             given column values. These Fields can be accessed by their names.
         """
-        elements = next(csv.reader([data], delimiter=delimiter))
+        elements = pd.read_csv(StringIO(data), delimiter=delimiter, header=None)
+        elements = elements.values.tolist()[0]
 
         if isinstance(self.fields, list):
             return self.from_list(elements)

--- a/podium/datasets/tabular_dataset.py
+++ b/podium/datasets/tabular_dataset.py
@@ -112,7 +112,11 @@ class TabularDataset(Dataset):
                 format = "custom"
             elif format in {"csv", "tsv"}:
                 delimiter = "," if format == "csv" else "\t"
-                reader = iter(pd.read_csv(f, delimiter=delimiter, header=None, **csv_reader_params).values.tolist())
+                reader = iter(
+                    pd.read_csv(
+                        f, delimiter=delimiter, header=None, **csv_reader_params
+                    ).values.tolist()
+                )
             elif format == "json":
                 reader = f
             else:

--- a/podium/datasets/tabular_dataset.py
+++ b/podium/datasets/tabular_dataset.py
@@ -1,5 +1,6 @@
-import csv
 import os
+
+import pandas as pd
 
 from podium.datasets.dataset import Dataset
 
@@ -19,7 +20,7 @@ class TabularDataset(Dataset):
         format="csv",
         line2example=None,
         skip_header=False,
-        csv_reader_params={},
+        csv_reader_params=None,
         **kwargs,
     ):
         """
@@ -71,7 +72,7 @@ class TabularDataset(Dataset):
         csv_reader_params : dict
             Parameters to pass to the csv reader. Only relevant when
             format is csv or tsv.
-            See https://docs.python.org/3/library/csv.html#csv.reader
+            See https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
             for more details.
 
         Raises
@@ -84,6 +85,7 @@ class TabularDataset(Dataset):
         """
 
         format = format.lower()
+        csv_reader_params = {} if csv_reader_params is None else csv_reader_params
 
         with open(os.path.expanduser(path), encoding="utf8") as f:
 
@@ -93,8 +95,7 @@ class TabularDataset(Dataset):
             if skip_header:
                 if format == "json":
                     raise ValueError(
-                        f"When using a {format} file, skip_header \
-                                       must be False."
+                        f"When using a {format} file, skip_header must be False."
                     )
                 elif format in {"csv", "tsv", "custom"} and isinstance(fields, dict):
                     raise ValueError(
@@ -111,7 +112,7 @@ class TabularDataset(Dataset):
                 format = "custom"
             elif format in {"csv", "tsv"}:
                 delimiter = "," if format == "csv" else "\t"
-                reader = csv.reader(f, delimiter=delimiter, **csv_reader_params)
+                reader = iter(pd.read_csv(f, delimiter=delimiter, header=None, **csv_reader_params).values.tolist())
             elif format == "json":
                 reader = f
             else:


### PR DESCRIPTION
This PR replaces `csv.reader` with `pd.read_csv` to avoid the "field larger than fied limit" error.